### PR TITLE
Fix recording of throwing methods

### DIFF
--- a/TestDRS/Sources/TestDRS/Spy/BlackBox.swift
+++ b/TestDRS/Sources/TestDRS/Spy/BlackBox.swift
@@ -26,7 +26,7 @@ public final class BlackBox {
     func recordCall<Input, Output>(
         with input: Input,
         at time: Date,
-        returning output: Output,
+        returning outputType: Output.Type,
         signature: String
     ) {
         storageQueue.async {
@@ -34,7 +34,7 @@ public final class BlackBox {
                 ConcreteFunctionCall(
                     signature: signature,
                     input: input,
-                    output: output,
+                    outputType: outputType,
                     time: time
                 )
             )
@@ -119,12 +119,15 @@ public final class BlackBox {
 extension BlackBox: CustomDebugStringConvertible {
     public var debugDescription: String {
         storageQueue.sync {
-            storage.enumerated().map { index, functionCall -> String in
-                """
-                ******* Function Call \(index + 1) *******
-                \(functionCall)
-                """
-            }.joined(separator: "\n \n") // The empty newline is stripped without the space inbetween.
+            "\n \n" +
+                storage.enumerated().map { index, functionCall -> String in
+                    """
+                    ******* Function Call \(index + 1) *******
+                    \(functionCall)
+                    """
+                }
+                .joined(separator: "\n \n") // The empty newline is stripped without the space inbetween.
+                + "\n "
         }
     }
 }

--- a/TestDRS/Sources/TestDRS/Spy/FunctionCall.swift
+++ b/TestDRS/Sources/TestDRS/Spy/FunctionCall.swift
@@ -19,7 +19,7 @@ public protocol FunctionCall: CustomDebugStringConvertible {
     var input: Input { get }
 
     /// The return type of the function.
-    var output: Output { get }
+    var outputType: Output.Type { get }
 
     /// The time at which the function was called.
     var time: Date { get }
@@ -30,7 +30,7 @@ extension FunctionCall {
         """
         signature: \(signature)
         input: \(input)
-        output: \(output)
+        outputType: \(outputType)
         time: \(FunctionCallUtilities.dateFormatter.string(from: time))
         """
     }
@@ -54,7 +54,7 @@ public struct ConcreteFunctionCall<Input, Output>: FunctionCall {
     public let input: Input
 
     /// The return type of the function.
-    public let output: Output
+    public let outputType: Output.Type
 
     /// The time at which the function was called.
     public let time: Date

--- a/TestDRS/Sources/TestDRS/Spy/Spy.swift
+++ b/TestDRS/Sources/TestDRS/Spy/Spy.swift
@@ -17,46 +17,41 @@ public extension Spy {
     /// - Parameters:
     ///   - input: The parameter(s) passed in to the function. For multiple parameters, use a tuple. Defaults to `Void()`.
     ///   - time: The time when the function was called.
-    ///   - output: The output that will be returned from the function.
+    ///   - outputType: The output type that will be returned from the function.
     ///   - signature: **Do not pass in this argument**, it will automatically capture the signature of the calling function.
-    /// - Returns: The un-modified `output` that was passed in to `recordCall`.
-    @discardableResult
     func recordCall<Input, Output>(
         with input: Input = Void(),
-        at time: Date,
-        returning output: Output = Void(),
+        at time: Date = Date(),
+        returning outputType: Output.Type = Void.self,
         signature: String = #function
-    ) -> Output {
+    ) {
         blackBox.recordCall(
             with: input,
             at: time,
-            returning: output,
+            returning: outputType,
             signature: signature
         )
-        return output
     }
 
     /// Records a static function call along with details about how it and when it was called.
     /// - Parameters:
     ///   - input: The parameter(s) passed in to the function. For multiple parameters, use a tuple. Defaults to `Void()`.
     ///   - time: The time when the function was called.
-    ///   - output: The output that will be returned from the function.
+    ///   - outputType: The output type that will be returned from the function.
     ///   - signature: **Do not pass in this argument**, it will automatically capture the signature of the calling function.
     /// - Returns: The un-modified `output` that was passed in to `recordCall`.
-    @discardableResult
     static func recordCall<Input, Output>(
         with input: Input = Void(),
         at time: Date = Date(),
-        returning output: Output = Void(),
+        returning outputType: Output.Type = Void.self,
         signature: String = #function
-    ) -> Output {
+    ) {
         blackBox.recordCall(
             with: input,
             at: time,
-            returning: output,
+            returning: outputType,
             signature: signature
         )
-        return output
     }
 
     /// Returns all instance function calls recorded within the `blackBox` that match the given signature.

--- a/TestDRS/Sources/TestDRS/Stub/StubProviding.swift
+++ b/TestDRS/Sources/TestDRS/Stub/StubProviding.swift
@@ -125,7 +125,7 @@ public extension StubProviding {
         for input: Input = Void(),
         signature: String = #function
     ) -> Output {
-        stubRegistry.stubOutput(for: input, signature: signature)
+        stubRegistry.stubOutput(for: input, signature: signature, in: Self.self)
     }
 
     /// Retrieves the stubbed output for the calling function based on the given input and expected output type, allowing for potential throwing of errors.
@@ -139,7 +139,7 @@ public extension StubProviding {
         for input: Input = Void(),
         signature: String = #function
     ) throws -> Output {
-        try stubRegistry.throwingStubOutput(for: input, signature: signature)
+        try stubRegistry.throwingStubOutput(for: input, signature: signature, in: Self.self)
     }
 
 }
@@ -242,7 +242,7 @@ public extension StubProviding {
         for input: Input = Void(),
         signature: String = #function
     ) -> Output {
-        stubRegistry.stubOutput(for: input, signature: signature)
+        stubRegistry.stubOutput(for: input, signature: signature, in: Self.self)
     }
 
     /// Retrieves the stubbed output for the calling function based on the given input and expected output type, allowing for potential throwing of errors.
@@ -256,7 +256,7 @@ public extension StubProviding {
         for input: Input = Void(),
         signature: String = #function
     ) throws -> Output {
-        try stubRegistry.throwingStubOutput(for: input, signature: signature)
+        try stubRegistry.throwingStubOutput(for: input, signature: signature, in: Self.self)
     }
 
 }

--- a/TestDRS/Tests/TestDRSTests/MockMacro/MockMacroExpansionTests+Protocol.swift
+++ b/TestDRS/Tests/TestDRSTests/MockMacro/MockMacroExpansionTests+Protocol.swift
@@ -42,44 +42,28 @@ extension MockMacroExpansionTests {
                 static let stubRegistry = StubRegistry()
 
                 func foo() throws -> String {
-                    let callTime = Date()
-                    return recordCall(at: callTime, returning: try throwingStubOutput())
+                    recordCall(returning: String.self)
+                    return try throwingStubOutput()
                 }
 
                 func bar(with paramOne: String) -> Int {
-                    let callTime = Date()
-                    return recordCall(
-                        with: paramOne,
-                        at: callTime,
-                        returning: stubOutput(for: paramOne)
-                    )
+                    recordCall(with: paramOne, returning: Int.self)
+                    return stubOutput(for: paramOne)
                 }
 
                 func baz(with paramOne: String, for paramTwo: String) -> Bool {
-                    let callTime = Date()
-                    return recordCall(
-                        with: (paramOne, paramTwo),
-                        at: callTime,
-                        returning: stubOutput(for: (paramOne, paramTwo))
-                    )
+                    recordCall(with: (paramOne, paramTwo), returning: Bool.self)
+                    return stubOutput(for: (paramOne, paramTwo))
                 }
 
                 func oof(with paramOne: String, for paramTwo: String, paramThree: Int) throws -> String {
-                    let callTime = Date()
-                    return recordCall(
-                        with: (paramOne, paramTwo, paramThree),
-                        at: callTime,
-                        returning: try throwingStubOutput(for: (paramOne, paramTwo, paramThree))
-                    )
+                    recordCall(with: (paramOne, paramTwo, paramThree), returning: String.self)
+                    return try throwingStubOutput(for: (paramOne, paramTwo, paramThree))
                 }
 
                 func rab(paramOne: Bool) {
-                    let callTime = Date()
-                    return recordCall(
-                        with: paramOne,
-                        at: callTime,
-                        returning: Void()
-                    )
+                    recordCall(with: paramOne)
+                    return stubOutput(for: paramOne)
                 }
 
             }
@@ -148,12 +132,8 @@ extension MockMacroExpansionTests {
                 }
 
                 static func oof(paramOne: String) -> Int {
-                    let callTime = Date()
-                    return recordCall(
-                        with: paramOne,
-                        at: callTime,
-                        returning: stubOutput(for: paramOne)
-                    )
+                    recordCall(with: paramOne, returning: Int.self)
+                    return stubOutput(for: paramOne)
                 }
 
             }
@@ -187,8 +167,8 @@ extension MockMacroExpansionTests {
                 static let stubRegistry = StubRegistry()
 
                 func foo<T>() -> T {
-                    let callTime = Date()
-                    return recordCall(at: callTime, returning: stubOutput())
+                    recordCall(returning: T.self)
+                    return stubOutput()
                 }
 
             }
@@ -222,8 +202,8 @@ extension MockMacroExpansionTests {
                 static let stubRegistry = StubRegistry()
 
                 func foo<T>() -> T where T: Equatable {
-                    let callTime = Date()
-                    return recordCall(at: callTime, returning: stubOutput())
+                    recordCall(returning: T.self)
+                    return stubOutput()
                 }
 
             }
@@ -257,8 +237,8 @@ extension MockMacroExpansionTests {
                 static let stubRegistry = StubRegistry()
 
                 func foo1() {
-                    let callTime = Date()
-                    return recordCall(at: callTime, returning: Void())
+                    recordCall()
+                    return stubOutput()
                 }
 
             }
@@ -305,8 +285,8 @@ extension MockMacroExpansionTests {
                 }
 
                 func bar() -> T {
-                    let callTime = Date()
-                    return recordCall(at: callTime, returning: stubOutput())
+                    recordCall(returning: T.self)
+                    return stubOutput()
                 }
 
             }

--- a/TestDRS/Tests/TestDRSTests/MockMacro/MockMacroExpansionTests+Struct.swift
+++ b/TestDRS/Tests/TestDRSTests/MockMacro/MockMacroExpansionTests+Struct.swift
@@ -82,45 +82,33 @@ extension MockMacroExpansionTests {
                 static let stubRegistry = StubRegistry()
 
                 func foo() {
-                    let callTime = Date()
-                    return recordCall(at: callTime, returning: Void())
+                    recordCall()
+                    return stubOutput()
                 }
 
                 func bar() -> Int {
-                    let callTime = Date()
-                    return recordCall(at: callTime, returning: stubOutput())
+                    recordCall(returning: Int.self)
+                    return stubOutput()
                 }
 
                 func baz(paramOne: String) -> Int {
-                    let callTime = Date()
-                    return recordCall(
-                        with: paramOne,
-                        at: callTime,
-                        returning: stubOutput(for: paramOne)
-                    )
+                    recordCall(with: paramOne, returning: Int.self)
+                    return stubOutput(for: paramOne)
                 }
 
                 func oof() throws -> Int {
-                    let callTime = Date()
-                    return recordCall(at: callTime, returning: try throwingStubOutput())
+                    recordCall(returning: Int.self)
+                    return try throwingStubOutput()
                 }
 
                 func rab(paramOne: Int, paramTwo: String, paramThree: bool) -> Int {
-                    let callTime = Date()
-                    return recordCall(
-                        with: (paramOne, paramTwo, paramThree),
-                        at: callTime,
-                        returning: stubOutput(for: (paramOne, paramTwo, paramThree))
-                    )
+                    recordCall(with: (paramOne, paramTwo, paramThree), returning: Int.self)
+                    return stubOutput(for: (paramOne, paramTwo, paramThree))
                 }
 
                 func zab(paramOne: Int) async throws -> Int {
-                    let callTime = Date()
-                    return recordCall(
-                        with: paramOne,
-                        at: callTime,
-                        returning: try throwingStubOutput(for: paramOne)
-                    )
+                    recordCall(with: paramOne, returning: Int.self)
+                    return try throwingStubOutput(for: paramOne)
                 }
 
             }
@@ -193,12 +181,8 @@ extension MockMacroExpansionTests {
                 }
 
                 static func oof(paramOne: String) -> Int {
-                    let callTime = Date()
-                    return recordCall(
-                        with: paramOne,
-                        at: callTime,
-                        returning: stubOutput(for: paramOne)
-                    )
+                    recordCall(with: paramOne, returning: Int.self)
+                    return stubOutput(for: paramOne)
                 }
 
             }
@@ -398,8 +382,8 @@ extension MockMacroExpansionTests {
                 }
 
                 func oof() {
-                    let callTime = Date()
-                    return recordCall(at: callTime, returning: Void())
+                    recordCall()
+                    return stubOutput()
                 }
 
             }
@@ -473,8 +457,8 @@ extension MockMacroExpansionTests {
                 }
 
                 func bar() {
-                    let callTime = Date()
-                    return recordCall(at: callTime, returning: Void())
+                    recordCall()
+                    return stubOutput()
                 }
 
             }
@@ -533,8 +517,8 @@ extension MockMacroExpansionTests {
                     }
 
                     func nestedBar() {
-                        let callTime = Date()
-                        return recordCall(at: callTime, returning: Void())
+                        recordCall()
+                        return stubOutput()
                     }
 
                 }
@@ -596,8 +580,8 @@ extension MockMacroExpansionTests {
                 }
 
                 func bar() -> T {
-                    let callTime = Date()
-                    return recordCall(at: callTime, returning: stubOutput())
+                    recordCall(returning: T.self)
+                    return stubOutput()
                 }
 
             }

--- a/TestDRS/Tests/TestDRSTests/Spy/Spy+AssertionsTests.swift
+++ b/TestDRS/Tests/TestDRSTests/Spy/Spy+AssertionsTests.swift
@@ -421,7 +421,7 @@ final class SpyAssertionsTests: SpyTestCase {
         zab(paramOne: "Hello World")
 
         let call = assertWasCalledExactlyOnce(zab(paramOne:), withSignature: "zab(paramOne:)", returning: String.self)
-        XCTAssertEqual(call?.output, "Hello World")
+        XCTAssertEqual(call?.input, "Hello World")
 
         XCTExpectFailure(
             failingBlock: {
@@ -704,7 +704,6 @@ final class SpyAssertionsTests: SpyTestCase {
         let callToOof = try XCTUnwrap(calls(to: "oof(paramOne:paramTwo:)").first)
         let firstCallToRab = try XCTUnwrap(calls(to: "rab(paramOne:paramTwo:paramThree:)").first)
 
-        let lastCallToRab = assertWasCalledLast(rab(paramOne:paramTwo:paramThree:), withSignature: "rab(paramOne:paramTwo:paramThree:)", expectedInput: true, 3, "World")
         assertWasCalledLast(rab(paramOne:paramTwo:paramThree:), withSignature: "rab(paramOne:paramTwo:paramThree:)", expectedInput: true, 3, "World", immediatelyAfter: firstCallToRab)
 
         XCTExpectFailure(
@@ -804,7 +803,7 @@ final class SpyAssertionsTests: SpyTestCase {
 
     func testAssertWasCalledAfter_WithoutCallingAnything() {
         XCTExpectFailure {
-            _ = assertWasCalled(foo, withSignature: "foo()", after: ConcreteFunctionCall(signature: "", input: Void(), output: Void(), time: Date()))
+            _ = assertWasCalled(foo, withSignature: "foo()", after: ConcreteFunctionCall(signature: "", input: Void(), outputType: Void.self, time: Date()))
         }
     }
 
@@ -886,7 +885,7 @@ final class SpyAssertionsTests: SpyTestCase {
 
     func testAssertWasCalledImmediatelyAfter_WithoutCallingAnything() {
         XCTExpectFailure {
-            _ = assertWasCalled(foo, withSignature: "foo()", immediatelyAfter: ConcreteFunctionCall(signature: "", input: Void(), output: Void(), time: Date()))
+            _ = assertWasCalled(foo, withSignature: "foo()", immediatelyAfter: ConcreteFunctionCall(signature: "", input: Void(), outputType: Void.self, time: Date()))
         }
     }
 

--- a/TestDRS/Tests/TestDRSTests/Spy/SpyTestCase.swift
+++ b/TestDRS/Tests/TestDRSTests/Spy/SpyTestCase.swift
@@ -46,12 +46,14 @@ class SpyTestCase: XCTestCase, Spy {
     @discardableResult
     func zab<T>(paramOne: T) -> T {
         defer { second += 1 }
-        return recordCall(with: paramOne, at: .functionCallTime(second: second), returning: paramOne)
+        recordCall(with: paramOne, at: .functionCallTime(second: second), returning: T.self)
+        return paramOne
     }
 
     func zoo<T: SomeProtocol>() -> T {
         defer { second += 1 }
-        return recordCall(at: .functionCallTime(second: second), returning: T())
+        recordCall(at: .functionCallTime(second: second), returning: T.self)
+        return T()
     }
 
 }

--- a/TestDRS/Tests/TestDRSTests/Spy/SpyTests.swift
+++ b/TestDRS/Tests/TestDRSTests/Spy/SpyTests.swift
@@ -147,17 +147,14 @@ final class SpyTests: SpyTestCase {
         XCTAssertEqual(calls[0].time, .functionCallTime(second: 0))
         XCTAssertEqual(calls[0].signature, "zab(paramOne:)")
         XCTAssertEqual(calls[0].input as? Bool, true)
-        XCTAssertEqual(calls[0].output as? Bool, true)
 
         XCTAssertEqual(calls[1].time, .functionCallTime(second: 1))
         XCTAssertEqual(calls[1].signature, "zab(paramOne:)")
         XCTAssertEqual(calls[1].input as? String, "Hello")
-        XCTAssertEqual(calls[1].output as? String, "Hello")
 
         XCTAssertEqual(calls[2].time, .functionCallTime(second: 2))
         XCTAssertEqual(calls[2].signature, "zab(paramOne:)")
         XCTAssertEqual(calls[2].input as? Int, 1)
-        XCTAssertEqual(calls[2].output as? Int, 1)
     }
 
 }

--- a/TestDRS/Tests/TestDRSTests/Stub/StubProvidingTests.swift
+++ b/TestDRS/Tests/TestDRSTests/Stub/StubProvidingTests.swift
@@ -10,6 +10,11 @@ final class StubProvidingTests: XCTestCase {
 
     private let stubProvider = StubProvider()
 
+    func testCallingMethodReturningVoid_WithoutStubbing() {
+        // Methods returning void should not need to be stubbed
+        return stubProvider.foo()
+    }
+
     func testStubbingFunctionWithNoParameters() {
         stubProvider.setStub(for: stubProvider.foo, withSignature: "foo()", returning: 7)
 
@@ -194,6 +199,10 @@ final class StubProvidingTests: XCTestCase {
 private struct StubProvider: StubProviding {
     let stubRegistry = StubRegistry()
     static let stubRegistry = StubRegistry()
+
+    func foo() {
+        return stubOutput()
+    }
 
     func foo() -> Int {
         stubOutput()


### PR DESCRIPTION
I had a realization when working with some example code that if a stubbed method is set to throw an error, any calls to it will never be recorded. This is due to the way that `recordCall` was set up to record the actual output when what we really needed was just the output type. I did it this way so that we wouldn't have to specify the output type explicitly but could just use the output from the stub registry to determine the output type. However, that only works if we don't throw an error first.

Consider this mocked method:

```
 override func zab(paramOne: Int) async throws -> Int {
        let callTime = Date()
        return recordCall(
            with: paramOne,
            at: callTime,
            returning: try throwingStubOutput(for: paramOne)
        )
}
```

If we register a stub for `zab(paramOne:) ` that throws an error, we will never actually call `recordCall` 😬. After this change, the mocked method will now look like this:

```
 override func zab(paramOne: Int) async throws -> Int {
        recordCall(with: paramOne, returning: Int.self)
        return try throwingStubOutput(for: paramOne)
}
```

We are guaranteed to record the call, and *then* we try getting the stub output which can throw. Since the mock method is generated by a macro, we have access to the return type syntax so that is not an issue either. I don't bother getting the call time explicitly either, as we won't be waiting to retrieve a stub output, and the call time probably doesn't need to be so exact anyway.