### PR TITLE
Final class diagnostic

### DIFF
--- a/Sources/TestDRSMacros/Mocking/AddMockExpansionDiagnostic.swift
+++ b/Sources/TestDRSMacros/Mocking/AddMockExpansionDiagnostic.swift
@@ -8,11 +8,14 @@ import SwiftDiagnostics
 enum AddMockExpansionDiagnostic: String, DiagnosticMessage {
 
     case invalidType
+    case finalClass
 
     var message: String {
         switch self {
         case .invalidType:
             "@AddMock can only be applied to protocols, classes, and structs"
+        case .finalClass:
+            "@AddMock can't be applied to final classes as they can not be subclassed to produce a mock."
         }
     }
 
@@ -21,18 +24,5 @@ enum AddMockExpansionDiagnostic: String, DiagnosticMessage {
     }
 
     var severity: DiagnosticSeverity { .error }
-
-}
-
-enum AddMockError: Error, CustomDebugStringConvertible {
-
-    case finalClass
-
-    var debugDescription: String {
-        switch self {
-        case .finalClass:
-            "@AddMock can't be applied to final classes as they can not be subclassed to produce a mock."
-        }
-    }
 
 }

--- a/Sources/TestDRSMacros/Mocking/AddMockExpansionDiagnostic.swift
+++ b/Sources/TestDRSMacros/Mocking/AddMockExpansionDiagnostic.swift
@@ -23,3 +23,16 @@ enum AddMockExpansionDiagnostic: String, DiagnosticMessage {
     var severity: DiagnosticSeverity { .error }
 
 }
+
+enum AddMockError: Error, CustomDebugStringConvertible {
+
+    case finalClass
+
+    var debugDescription: String {
+        switch self {
+        case .finalClass:
+            "@AddMock can't be applied to final classes as they can not be subclassed to produce a mock."
+        }
+    }
+
+}

--- a/Sources/TestDRSMacros/Mocking/AddMockMacroExpansion.swift
+++ b/Sources/TestDRSMacros/Mocking/AddMockMacroExpansion.swift
@@ -22,7 +22,7 @@ public struct AddMockMacro: PeerMacro {
         if let protocolDeclaration = declaration.as(ProtocolDeclSyntax.self) {
             mockDeclaration = DeclSyntax(mockClassDeclaration(from: protocolDeclaration))
         } else if let classDeclaration = declaration.as(ClassDeclSyntax.self) {
-            mockDeclaration = DeclSyntax(try mockSubclassDeclaration(from: classDeclaration))
+            mockDeclaration = DeclSyntax(mockSubclassDeclaration(from: classDeclaration, context: context))
         } else if let structDeclaration = declaration.as(StructDeclSyntax.self) {
             mockDeclaration = DeclSyntax(mockStruct(from: structDeclaration))
         } else {
@@ -80,9 +80,14 @@ public struct AddMockMacro: PeerMacro {
         return classDeclaration
     }
 
-    private static func mockSubclassDeclaration(from classDeclaration: ClassDeclSyntax) throws -> ClassDeclSyntax {
-        guard !classDeclaration.modifiers.containsKeyword(.final) else {
-            throw AddMockError.finalClass
+    private static func mockSubclassDeclaration(from classDeclaration: ClassDeclSyntax, context: some MacroExpansionContext) -> ClassDeclSyntax {
+        if classDeclaration.modifiers.containsKeyword(.final) {
+            context.diagnose(
+                Diagnostic(
+                    node: Syntax(classDeclaration),
+                    message: AddMockExpansionDiagnostic.finalClass
+                )
+            )
         }
         let className = classDeclaration.name.trimmed.text
 

--- a/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionTests+Class.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionTests+Class.swift
@@ -44,7 +44,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             class SomeClass: ProtocolOne, ProtocolTwo {
 
                 func foo() {
@@ -72,6 +71,47 @@ extension AddMockMacroExpansionTests {
                 }
 
             }
+
+            #if DEBUG
+
+            final class MockSomeClass: SomeClass, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                override func foo() {
+                    recordCall()
+                    return stubOutput()
+                }
+
+                override func bar() -> Int {
+                    recordCall(returning: Int.self)
+                    return stubOutput()
+                }
+
+                override func baz(paramOne: String) -> Int {
+                    recordCall(with: paramOne, returning: Int.self)
+                    return stubOutput(for: paramOne)
+                }
+
+                override func oof() throws -> Int {
+                    recordCall(returning: Int.self)
+                    return try throwingStubOutput()
+                }
+
+                override func rab(paramOne: Int, paramTwo: String, paramThree: bool) -> Int {
+                    recordCall(with: (paramOne, paramTwo, paramThree), returning: Int.self)
+                    return stubOutput(for: (paramOne, paramTwo, paramThree))
+                }
+
+                override func zab(paramOne: Int) async throws -> (() -> Void) {
+                    recordCall(with: paramOne, returning: (() -> Void).self)
+                    return try throwingStubOutput(for: paramOne)
+                }
+
+            }
+
+            #endif
             """
         }
     }
@@ -95,7 +135,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             class SomeClass {
                 var foo = "Hello World"
                 class var bar: Int {
@@ -108,6 +147,47 @@ extension AddMockMacroExpansionTests {
                     fatalError("Unimplemented")
                 }
             }
+
+            #if DEBUG
+
+            final class MockSomeClass: SomeClass, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                override var foo {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                class override var bar: Int {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                class override var baz: Bool {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+
+                class override func oof(paramOne: String) -> Int {
+                    recordCall(with: paramOne, returning: Int.self)
+                    return stubOutput(for: paramOne)
+                }
+
+            }
+
+            #endif
             """
         }
     }
@@ -128,7 +208,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             class SomeClass {
                 var foo = "Hello World"
                 static var bar = 7
@@ -138,6 +217,25 @@ extension AddMockMacroExpansionTests {
                     fatalError("Unimplemented")
                 }
             }
+
+            #if DEBUG
+
+            final class MockSomeClass: SomeClass, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                override var foo {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+            }
+
+            #endif
             """
         }
     }
@@ -156,7 +254,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             class SomeClass: SomeSuperclass {
                 override var foo = "Hello World"
 
@@ -164,6 +261,31 @@ extension AddMockMacroExpansionTests {
                     fatalError("Unimplemented")
                 }
             }
+
+            #if DEBUG
+
+            final class MockSomeClass: SomeClass, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                override var foo {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+
+                override func bar() -> Int {
+                    recordCall(returning: Int.self)
+                    return stubOutput()
+                }
+
+            }
+
+            #endif
             """
         }
     }
@@ -189,7 +311,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             class SomeClass {
                 var foo: String {
                     "Hello World"
@@ -204,6 +325,41 @@ extension AddMockMacroExpansionTests {
                     set {}
                 }
             }
+
+            #if DEBUG
+
+            final class MockSomeClass: SomeClass, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                override var foo: String {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                override var bar: String {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                override var baz: String {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+            }
+
+            #endif
             """
         }
     }
@@ -219,11 +375,37 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             class SomeClass {
                 var foo: String?
                 let bar: Int!
             }
+
+            #if DEBUG
+
+            final class MockSomeClass: SomeClass, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                override var foo: String? {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                override var bar: Int! {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+            }
+
+            #endif
             """
         }
     }
@@ -249,7 +431,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             class SomeClass {
                 var foo: String
 
@@ -264,6 +445,31 @@ extension AddMockMacroExpansionTests {
                     fatalError("Unimplemented")
                 }
             }
+
+            #if DEBUG
+
+            final class MockSomeClass: SomeClass, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                override var foo: String {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+
+                override func oof() {
+                    recordCall()
+                    return stubOutput()
+                }
+
+            }
+
+            #endif
             """
         }
     }
@@ -290,7 +496,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             class SomeClass {
                 var x: String
                 var y: Int
@@ -306,6 +511,54 @@ extension AddMockMacroExpansionTests {
 
                 func foo() {}
             }
+
+            #if DEBUG
+
+            final class MockSomeClass: SomeClass, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                override var x: String {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                override var y: Int {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                override var myZ: Bool {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+
+                override init(_ x: String, y: Int, andZ z: Bool) {
+                    super.init(x, y: y, andZ: z)
+                    self.x = x
+                    self.y = y
+                    myZ = z
+                }
+
+                override func foo() {
+                    recordCall()
+                    return stubOutput()
+                }
+
+            }
+
+            #endif
             """
         }
     }
@@ -335,7 +588,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             class SomeClass {
                 var x: String
                 var y: Int
@@ -354,6 +606,48 @@ extension AddMockMacroExpansionTests {
                 }
 
             }
+
+            #if DEBUG
+
+            final class MockSomeClass: SomeClass, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                override var x: String {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                override var y: Int {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                override var z: Bool {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+
+                override init(x: String, y: Int, z: Bool) {
+                    super.init(x: x, y: y, z: z)
+                    self.x = x
+                    self.y = y
+                    self.z = z
+                }
+            }
+
+            #endif
             """
         }
     }
@@ -372,7 +666,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             class SomeClass {
                 var x = "Hello World"
                 final let y = 7
@@ -380,6 +673,25 @@ extension AddMockMacroExpansionTests {
 
                 final func foo() {}
             }
+
+            #if DEBUG
+
+            final class MockSomeClass: SomeClass, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                override var x {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+            }
+
+            #endif
             """
         }
     }

--- a/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionTests+Protocol.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionTests+Protocol.swift
@@ -24,7 +24,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             protocol SomeProtocol {
                 func foo() throws -> String
                 func bar(with paramOne: String) -> Int
@@ -32,6 +31,42 @@ extension AddMockMacroExpansionTests {
                 func oof(with paramOne: String, for paramTwo: String, paramThree: Int) throws -> String
                 mutating func rab(paramOne: Bool)
             }
+
+            #if DEBUG
+
+            final class MockSomeProtocol: SomeProtocol, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                func foo() throws -> String {
+                    recordCall(returning: String.self)
+                    return try throwingStubOutput()
+                }
+
+                func bar(with paramOne: String) -> Int {
+                    recordCall(with: paramOne, returning: Int.self)
+                    return stubOutput(for: paramOne)
+                }
+
+                func baz(with paramOne: String, for paramTwo: String) -> Bool {
+                    recordCall(with: (paramOne, paramTwo), returning: Bool.self)
+                    return stubOutput(for: (paramOne, paramTwo))
+                }
+
+                func oof(with paramOne: String, for paramTwo: String, paramThree: Int) throws -> String {
+                    recordCall(with: (paramOne, paramTwo, paramThree), returning: String.self)
+                    return try throwingStubOutput(for: (paramOne, paramTwo, paramThree))
+                }
+
+                func rab(paramOne: Bool) {
+                    recordCall(with: paramOne)
+                    return stubOutput(for: paramOne)
+                }
+
+            }
+
+            #endif
             """
         }
     }
@@ -50,7 +85,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             protocol SomeProtocol {
                 var foo: String { get }
                 static var bar: Int { get set }
@@ -58,6 +92,47 @@ extension AddMockMacroExpansionTests {
 
                 static func oof(paramOne: String) -> Int
             }
+
+            #if DEBUG
+
+            final class MockSomeProtocol: SomeProtocol, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                var foo: String {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                static var bar: Int {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                static var baz: Bool {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+
+                static func oof(paramOne: String) -> Int {
+                    recordCall(with: paramOne, returning: Int.self)
+                    return stubOutput(for: paramOne)
+                }
+
+            }
+
+            #endif
             """
         }
     }
@@ -72,10 +147,25 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             protocol SomeProtocol {
                 func foo<T>() -> T
             }
+
+            #if DEBUG
+
+            final class MockSomeProtocol: SomeProtocol, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                func foo<T>() -> T {
+                    recordCall(returning: T.self)
+                    return stubOutput()
+                }
+
+            }
+
+            #endif
             """
         }
     }
@@ -90,10 +180,25 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             protocol SomeProtocol {
                 func foo<T>() -> T where T: Equatable
             }
+
+            #if DEBUG
+
+            final class MockSomeProtocol: SomeProtocol, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                func foo<T>() -> T where T: Equatable {
+                    recordCall(returning: T.self)
+                    return stubOutput()
+                }
+
+            }
+
+            #endif
             """
         }
     }
@@ -108,10 +213,25 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             @objc protocol SomeProtocol {
                 func foo1()
             }
+
+            #if DEBUG
+
+            @objc final class MockSomeProtocol: NSObject, SomeProtocol, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                func foo1() {
+                    recordCall()
+                    return stubOutput()
+                }
+
+            }
+
+            #endif
             """
         }
     }
@@ -128,12 +248,36 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             protocol SomeProtocol<T> {
                 associatedtype T
                 var foo: T
                 func bar() -> T
             }
+
+            #if DEBUG
+
+            final class MockSomeProtocol<T>: SomeProtocol, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                var foo: T {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+
+                func bar() -> T {
+                    recordCall(returning: T.self)
+                    return stubOutput()
+                }
+
+            }
+
+            #endif
             """
         }
     }

--- a/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionTests+Struct.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionTests+Struct.swift
@@ -44,7 +44,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             struct SomeStruct: ProtocolOne, ProtocolTwo {
 
                 func foo() {
@@ -72,6 +71,47 @@ extension AddMockMacroExpansionTests {
                 }
 
             }
+
+            #if DEBUG
+
+            struct MockSomeStruct: ProtocolOne, ProtocolTwo, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                func foo() {
+                    recordCall()
+                    return stubOutput()
+                }
+
+                func bar() -> Int {
+                    recordCall(returning: Int.self)
+                    return stubOutput()
+                }
+
+                func baz(paramOne: String) -> Int {
+                    recordCall(with: paramOne, returning: Int.self)
+                    return stubOutput(for: paramOne)
+                }
+
+                func oof() throws -> Int {
+                    recordCall(returning: Int.self)
+                    return try throwingStubOutput()
+                }
+
+                func rab(paramOne: Int, paramTwo: String, paramThree: bool) -> Int {
+                    recordCall(with: (paramOne, paramTwo, paramThree), returning: Int.self)
+                    return stubOutput(for: (paramOne, paramTwo, paramThree))
+                }
+
+                func zab(paramOne: Int) async throws -> Int {
+                    recordCall(with: paramOne, returning: Int.self)
+                    return try throwingStubOutput(for: paramOne)
+                }
+
+            }
+
+            #endif
             """
         }
     }
@@ -92,7 +132,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             struct SomeStruct {
                 var foo = "Hello World"
                 static var bar = 7
@@ -102,6 +141,47 @@ extension AddMockMacroExpansionTests {
                     fatalError("Unimplemented")
                 }
             }
+
+            #if DEBUG
+
+            struct MockSomeStruct: Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                var foo {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                static var bar {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                static var baz: Bool {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+
+                static func oof(paramOne: String) -> Int {
+                    recordCall(with: paramOne, returning: Int.self)
+                    return stubOutput(for: paramOne)
+                }
+
+            }
+
+            #endif
             """
         }
     }
@@ -128,7 +208,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             struct SomeStruct {
                 var foo: String {
                     "Hello World"
@@ -144,6 +223,41 @@ extension AddMockMacroExpansionTests {
                 }
 
             }
+
+            #if DEBUG
+
+            struct MockSomeStruct: Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                var foo: String {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                var bar: String {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                var baz: String {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+            }
+
+            #endif
             """
         }
     }
@@ -161,13 +275,39 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             struct SomeStruct {
 
                 var foo: String?
                 let bar: Int!
 
             }
+
+            #if DEBUG
+
+            struct MockSomeStruct: Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                var foo: String? {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                var bar: Int! {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+            }
+
+            #endif
             """
         }
     }
@@ -194,7 +334,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             struct SomeStruct {
 
                 var foo: String
@@ -210,6 +349,31 @@ extension AddMockMacroExpansionTests {
                     fatalError("Unimplemented")
                 }
             }
+
+            #if DEBUG
+
+            struct MockSomeStruct: Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                var foo: String {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+
+                func oof() {
+                    recordCall()
+                    return stubOutput()
+                }
+
+            }
+
+            #endif
             """
         }
     }
@@ -236,7 +400,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             struct SomeStruct {
 
                 struct NestedStruct {
@@ -252,6 +415,38 @@ extension AddMockMacroExpansionTests {
                     fatalError("Unimplemented")
                 }
             }
+
+            #if DEBUG
+
+            struct MockSomeStruct: Mock {
+
+                struct NestedStruct {
+                    let nestedFoo: String
+                    func nestedBar() {
+                        fatalError("Unimplemented")
+                    }
+                }
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                var foo: NestedStruct {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+
+                func bar() {
+                    recordCall()
+                    return stubOutput()
+                }
+
+            }
+
+            #endif
             """
         }
     }
@@ -279,14 +474,37 @@ extension AddMockMacroExpansionTests {
         } expansion: {
             """
             struct SomeStruct {
-
-                @AddMock
                 struct NestedStruct {
                     let nestedFoo: String
                     func nestedBar() {
                         fatalError("Unimplemented")
                     }
                 }
+
+                #if DEBUG
+
+                struct MockNestedStruct: Mock {
+
+                    let blackBox = BlackBox()
+                    let stubRegistry = StubRegistry()
+
+                    var nestedFoo: String {
+                        get {
+                            stubValue()
+                        }
+                        set {
+                            setStub(value: newValue)
+                        }
+                    }
+
+                    func nestedBar() {
+                        recordCall()
+                        return stubOutput()
+                    }
+
+                }
+
+                #endif
 
                 var foo: NestedStruct
 
@@ -314,7 +532,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             struct SomeStruct<T> {
 
                 var foo: T
@@ -324,6 +541,31 @@ extension AddMockMacroExpansionTests {
                 }
 
             }
+
+            #if DEBUG
+
+            struct MockSomeStruct<T> : Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                var foo: T {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+
+                func bar() -> T {
+                    recordCall(returning: T.self)
+                    return stubOutput()
+                }
+
+            }
+
+            #endif
             """
         }
     }
@@ -350,7 +592,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             struct SomeStruct {
                 var x: String
                 var y: Int
@@ -366,6 +607,47 @@ extension AddMockMacroExpansionTests {
 
                 func foo() {}
             }
+
+            #if DEBUG
+
+            struct MockSomeStruct: Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                var x: String {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                var y: Int {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                var myZ: Bool {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+
+                func foo() {
+                    recordCall()
+                    return stubOutput()
+                }
+
+            }
+
+            #endif
             """
         }
     }
@@ -388,7 +670,6 @@ extension AddMockMacroExpansionTests {
             """
         } expansion: {
             """
-            @AddMock
             struct SomeStruct {
                 let a: String = "Hello World"
                 var b: [Int] = [1, 2, 3]
@@ -398,6 +679,65 @@ extension AddMockMacroExpansionTests {
                 var y = [1, 2, 3]
                 var z = ["YES": true, "NO": false]
             }
+
+            #if DEBUG
+
+            struct MockSomeStruct: Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                var a: String {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                var b: [Int] {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                var c: [String: Bool] {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                var x {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                var y {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                var z {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+            }
+
+            #endif
             """
         }
     }

--- a/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionTests.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionTests.swift
@@ -79,7 +79,6 @@ final class AddMockMacroExpansionTests: XCTestCase {
         } diagnostics: {
             """
             @AddMock
-            ┬───────
             ╰─ 🛑 @AddMock can't be applied to final classes as they can not be subclassed to produce a mock.
             final class SomeClass {
                 var foo = "Hello World"

--- a/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionTests.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class AddMockMacroExpansionTests: XCTestCase {
 
     override func invokeTest() {
-        withMacroTesting(macros: ["Mock": AddMockMacro.self, "__MockProperty": MockPropertyMacro.self]) {
+        withMacroTesting(macros: ["AddMock": AddMockMacro.self, "__MockProperty": MockPropertyMacro.self]) {
             super.invokeTest()
         }
     }
@@ -28,11 +28,9 @@ final class AddMockMacroExpansionTests: XCTestCase {
             """
         } diagnostics: {
             """
-
-            """
-        } expansion: {
-            """
             @AddMock
+            ┬───────
+            ╰─ 🛑 @AddMock can only be applied to protocols, classes, and structs
             enum SomeEnum {
                 case foo
                 case bar
@@ -54,12 +52,36 @@ final class AddMockMacroExpansionTests: XCTestCase {
             """
         } diagnostics: {
             """
-
+            @AddMock
+            ┬───────
+            ╰─ 🛑 @AddMock can only be applied to protocols, classes, and structs
+            actor SomeActor {
+                var foo = "Hello World"
+                func bar() {
+                    // fatalError("Unimplemented")
+                }
+            }
             """
-        } expansion: {
+        }
+    }
+
+    func testAddMockMacro_WithFinalClass_ProducesDiagnostic() {
+        assertMacro {
             """
             @AddMock
-            actor SomeActor {
+            final class SomeClass {
+                var foo = "Hello World"
+                func bar() {
+                    // fatalError("Unimplemented")
+                }
+            }
+            """
+        } diagnostics: {
+            """
+            @AddMock
+            ┬───────
+            ╰─ 🛑 @AddMock can't be applied to final classes as they can not be subclassed to produce a mock.
+            final class SomeClass {
                 var foo = "Hello World"
                 func bar() {
                     // fatalError("Unimplemented")


### PR DESCRIPTION
This addresses issue #11 by producing a diagnostic if you attempt to apply `@AddMock` to a final class. It also fixes some tests that I apparently recorded incorrect expansions for when refactoring last year, as well as cleaning up some methods that didn't need to be marked as throwing.