### PR TITLE
Add inputType parameter to disambiguate stub

### DIFF
--- a/Sources/TestDRS/Macros/StubMacros.swift
+++ b/Sources/TestDRS/Macros/StubMacros.swift
@@ -7,25 +7,29 @@
 ///
 /// - Parameters:
 ///   - function: The function to stub. The specified function must be a member of a `StubProviding` type.
+///   - inputType: An optional phantom parameter used to derive the input type of the `function` passed in.
 ///   - output: The output value to be returned when the function is called.
-///
-///   - Note: The compiler will not be able to disambiguate when stubbing functions that are overloaded *and* share the same output type.
-///   If that is the case, use `#stub(_:using:)` and specify the input to the closure explicitly.
 @freestanding(expression)
 @discardableResult
-public macro stub<Input, Output>(_ function: (Input) async throws -> Output, returning output: Output) -> Void = #externalMacro(module: "TestDRSMacros", type: "SetStubReturningOutputMacro")
+public macro stub<Input, Output>(
+    _ function: (Input) async throws -> Output,
+    taking inputType: Input.Type? = nil,
+    returning output: Output
+) -> Void = #externalMacro(module: "TestDRSMacros", type: "SetStubReturningOutputMacro")
 
 /// Sets a stub for a given function to throw a provided error.
 ///
 /// - Parameters:
 ///   - function: The function to stub. The specified function must be a member of a `StubProviding` type.
+///   - inputType: An optional phantom parameter used to derive the input type of the `function` passed in.
 ///   - error: The error to be thrown when the function is called.
-///
-///   - Note: The compiler will not be able to disambiguate when stubbing functions that are overloaded *and* share the same output type.
-///   If that is the case, use `#stub(_:using:)` and specify the input to the closure explicitly.
 @freestanding(expression)
 @discardableResult
-public macro stub<Input, Output>(_ function: (Input) async throws -> Output, throwing error: Error) -> Void = #externalMacro(module: "TestDRSMacros", type: "SetStubThrowingErrorMacro")
+public macro stub<Input, Output>(
+    _ function: (Input) async throws -> Output,
+    taking inputType: Input.Type? = nil,
+    throwing error: Error
+) -> Void = #externalMacro(module: "TestDRSMacros", type: "SetStubThrowingErrorMacro")
 
 /// Sets a stub for a given function using a closure to dynamically determine the output.
 ///

--- a/Sources/TestDRS/Stub/StubProviding.swift
+++ b/Sources/TestDRS/Stub/StubProviding.swift
@@ -47,6 +47,7 @@ public extension StubProviding {
     func setStub<Input, Output>(
         for function: (Input) async throws -> Output,
         withSignature signature: FunctionSignature,
+        taking inputType: Input.Type? = nil,
         returning output: Output
     ) {
         stubRegistry.register(output: output, for: function, withSignature: signature)
@@ -65,6 +66,7 @@ public extension StubProviding {
     func setStub<Input, Output>(
         for function: (Input) async throws -> Output,
         withSignature signature: FunctionSignature,
+        taking inputType: Input.Type? = nil,
         throwing error: Error
     ) {
         stubRegistry.register(error: error, for: function, withSignature: signature)
@@ -168,6 +170,7 @@ public extension StubProviding {
     static func setStub<Input, Output>(
         for function: (Input) async throws -> Output,
         withSignature signature: FunctionSignature,
+        taking inputType: Input.Type? = nil,
         returning output: Output
     ) {
         getStaticStubRegistry().register(output: output, for: function, withSignature: signature)
@@ -186,6 +189,7 @@ public extension StubProviding {
     static func setStub<Input, Output>(
         for function: (Input) async throws -> Output,
         withSignature signature: FunctionSignature,
+        taking inputType: Input.Type? = nil,
         throwing error: Error
     ) {
         getStaticStubRegistry().register(error: error, for: function, withSignature: signature)

--- a/Sources/TestDRSMacros/Stubbing/StubMacroExpansion.swift
+++ b/Sources/TestDRSMacros/Stubbing/StubMacroExpansion.swift
@@ -14,7 +14,7 @@ public struct SetStubReturningOutputMacro: ExpressionMacro {
         of node: some FreestandingMacroExpansionSyntax,
         in context: some MacroExpansionContext
     ) -> ExprSyntax {
-        guard node.arguments.count == 2,
+        guard (2 ... 3).contains(node.arguments.count),
               let firstArgument = node.arguments.first?.expression,
               let output = node.arguments.last?.expression
         else {
@@ -30,13 +30,17 @@ public struct SetStubReturningOutputMacro: ExpressionMacro {
             return ""
         }
 
+        let inputType = node.arguments.first { argument in
+            argument.label?.text == "taking"
+        }?.expression
+
         if let memberAccess = firstArgument.as(MemberAccessExprSyntax.self), let base = memberAccess.base {
             return """
-            \(base).setStub(for: \(memberAccess), withSignature: "\(memberAccess.declName)", returning: \(output))
+            \(base).setStub(for: \(memberAccess), withSignature: "\(memberAccess.declName)", taking: \(inputType == nil ? "nil" : "\(inputType)"), returning: \(output))
             """
         } else if let expression = firstArgument.as(DeclReferenceExprSyntax.self) {
             return """
-            setStub(for: \(expression), withSignature: "\(expression.argumentNames == nil ? "\(expression)()" : "\(expression)")", returning: \(output))
+            setStub(for: \(expression), withSignature: "\(expression.argumentNames == nil ? "\(expression)()" : "\(expression)")", taking: \(inputType == nil ? "nil" : "\(inputType)"), returning: \(output))
             """
         } else {
             context.diagnose(
@@ -55,7 +59,7 @@ public struct SetStubThrowingErrorMacro: ExpressionMacro {
         of node: some FreestandingMacroExpansionSyntax,
         in context: some MacroExpansionContext
     ) -> ExprSyntax {
-        guard node.arguments.count == 2,
+        guard (2 ... 3).contains(node.arguments.count),
               let firstArgument = node.arguments.first?.expression,
               let error = node.arguments.last?.expression
         else {
@@ -71,13 +75,17 @@ public struct SetStubThrowingErrorMacro: ExpressionMacro {
             return ""
         }
 
+        let inputType = node.arguments.first { argument in
+            argument.label?.text == "taking"
+        }?.expression
+
         if let memberAccess = firstArgument.as(MemberAccessExprSyntax.self), let base = memberAccess.base {
             return """
-            \(base).setStub(for: \(memberAccess), withSignature: "\(memberAccess.declName)", throwing: \(error))
+            \(base).setStub(for: \(memberAccess), withSignature: "\(memberAccess.declName)", taking: \(inputType == nil ? "nil" : "\(inputType)"), throwing: \(error))
             """
         } else if let expression = firstArgument.as(DeclReferenceExprSyntax.self) {
             return """
-            setStub(for: \(expression), withSignature: "\(expression.argumentNames == nil ? "\(expression)()" : "\(expression)")", throwing: \(error))
+            setStub(for: \(expression), withSignature: "\(expression.argumentNames == nil ? "\(expression)()" : "\(expression)")", taking: \(inputType == nil ? "nil" : "\(inputType)"), throwing: \(error))
             """
         } else {
             context.diagnose(

--- a/Tests/TestDRSMacrosTests/Stubbing/SetStubReturningOutputMacroExpansionTests.swift
+++ b/Tests/TestDRSMacrosTests/Stubbing/SetStubReturningOutputMacroExpansionTests.swift
@@ -24,7 +24,7 @@ final class SetStubReturningOutputMacroTests: XCTestCase {
             """
         } expansion: {
             """
-            mock.setStub(for: mock.foo, withSignature: "foo", returning: "Hello World")
+            mock.setStub(for: mock.foo, withSignature: "foo", taking: nil, returning: "Hello World")
             """
         }
     }
@@ -36,7 +36,7 @@ final class SetStubReturningOutputMacroTests: XCTestCase {
             """
         } expansion: {
             """
-            mock.setStub(for: mock.foo(_:paramTwo:), withSignature: "foo(_:paramTwo:)", returning: "Hello World")
+            mock.setStub(for: mock.foo(_:paramTwo:), withSignature: "foo(_:paramTwo:)", taking: nil, returning: "Hello World")
             """
         }
     }
@@ -48,7 +48,7 @@ final class SetStubReturningOutputMacroTests: XCTestCase {
             """
         } expansion: {
             """
-            setStub(for: foo, withSignature: "foo()", returning: "Hello World")
+            setStub(for: foo, withSignature: "foo()", taking: nil, returning: "Hello World")
             """
         }
     }
@@ -60,7 +60,19 @@ final class SetStubReturningOutputMacroTests: XCTestCase {
             """
         } expansion: {
             """
-            setStub(for: foo(_:paramTwo:), withSignature: "foo(_:paramTwo:)", returning: "Hello World")
+            setStub(for: foo(_:paramTwo:), withSignature: "foo(_:paramTwo:)", taking: nil, returning: "Hello World")
+            """
+        }
+    }
+
+    func testStubbingMethod_WithInputTypeSpecified() {
+        assertMacro {
+            """
+            #stub(foo, taking: Int.self, returning: "Hello World")
+            """
+        } expansion: {
+            """
+            setStub(for: foo, withSignature: "foo()", taking: Int.self, returning: "Hello World")
             """
         }
     }

--- a/Tests/TestDRSMacrosTests/Stubbing/SetStubThrowingErrorMacroExpansionTests.swift
+++ b/Tests/TestDRSMacrosTests/Stubbing/SetStubThrowingErrorMacroExpansionTests.swift
@@ -24,7 +24,7 @@ final class SetStubThrowingErrorMacroExpansionTests: XCTestCase {
             """
         } expansion: {
             """
-            mock.setStub(for: mock.foo, withSignature: "foo", throwing: MyError.someError)
+            mock.setStub(for: mock.foo, withSignature: "foo", taking: nil, throwing: MyError.someError)
             """
         }
     }
@@ -36,7 +36,7 @@ final class SetStubThrowingErrorMacroExpansionTests: XCTestCase {
             """
         } expansion: {
             """
-            mock.setStub(for: mock.foo(_:paramTwo:), withSignature: "foo(_:paramTwo:)", throwing: MyError.someError)
+            mock.setStub(for: mock.foo(_:paramTwo:), withSignature: "foo(_:paramTwo:)", taking: nil, throwing: MyError.someError)
             """
         }
     }
@@ -48,7 +48,7 @@ final class SetStubThrowingErrorMacroExpansionTests: XCTestCase {
             """
         } expansion: {
             """
-            setStub(for: foo, withSignature: "foo()", throwing: MyError.someError)
+            setStub(for: foo, withSignature: "foo()", taking: nil, throwing: MyError.someError)
             """
         }
     }
@@ -60,7 +60,19 @@ final class SetStubThrowingErrorMacroExpansionTests: XCTestCase {
             """
         } expansion: {
             """
-            setStub(for: foo(_:paramTwo:), withSignature: "foo(_:paramTwo:)", throwing: MyError.someError)
+            setStub(for: foo(_:paramTwo:), withSignature: "foo(_:paramTwo:)", taking: nil, throwing: MyError.someError)
+            """
+        }
+    }
+
+    func testStubbingMethod_WithInputTypeSpecified() {
+        assertMacro {
+            """
+            #stub(foo, taking: Int.self, throwing: MyError.someError)
+            """
+        } expansion: {
+            """
+            setStub(for: foo, withSignature: "foo()", taking: Int.self, throwing: MyError.someError)
             """
         }
     }

--- a/Tests/TestDRSTests/Integration/StubTypeDisambiguationTests.swift
+++ b/Tests/TestDRSTests/Integration/StubTypeDisambiguationTests.swift
@@ -1,0 +1,48 @@
+//
+// Created on 1/16/25.
+// Copyright © 2025 Turo Open Source. All rights reserved.
+//
+
+import TestDRS
+import Testing
+
+struct StubTypeDisambiguationTests {
+
+    private let mock = MockDisambiguationTesting()
+
+    @Test func disambiguateInputType_ReturningOutput() {
+        #stub(mock.foo, taking: String.self, returning: "Taking a String")
+        #stub(mock.foo, taking: Bool.self, returning: "Taking a Bool")
+
+        #expect(mock.foo(paramOne: "Hello World") == "Taking a String")
+        #expect(mock.foo(paramOne: true) == "Taking a Bool")
+    }
+
+    @Test func disambiguateInputType_ThrowingError() {
+        #stub(mock.bar, taking: String.self, throwing: MockError.stringInput)
+        #stub(mock.bar, taking: Bool.self, throwing: MockError.boolInput)
+
+        #expect(throws: MockError.stringInput) {
+            try mock.bar(paramOne: "Hello World")
+        }
+        #expect(throws: MockError.boolInput) {
+            try mock.bar(paramOne: true)
+        }
+    }
+
+}
+
+@AddMock
+private protocol DisambiguationTesting {
+
+    func foo(paramOne: String) -> String
+    func foo(paramOne: Bool) -> String
+    func bar(paramOne: String) throws
+    func bar(paramOne: Bool) throws
+
+}
+
+private enum MockError: Error {
+    case stringInput
+    case boolInput
+}


### PR DESCRIPTION
Addresses issue #10 by adding a phantom parameter so that you can disambiguate when a function is overloaded with multiple input types.