### PR TITLE
Integration fixes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-issue-reporting",
       "state" : {
-        "revision" : "357ca1e5dd31f613a1d43320870ebc219386a495",
-        "version" : "1.2.2"
+        "revision" : "b444594f79844b0d6d76d70fbfb3f7f71728f938",
+        "version" : "1.5.1"
       }
     },
     {
@@ -34,15 +34,6 @@
       "state" : {
         "revision" : "0687f71944021d616d34d922343dcef086855920",
         "version" : "600.0.1"
-      }
-    },
-    {
-      "identity" : "swift-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-testing.git",
-      "state" : {
-        "revision" : "69d59cfc76e5daf498ca61f5af409f594768eef9",
-        "version" : "0.10.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "swift-issue-reporting",
+      "identity" : "swift-custom-dump",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-issue-reporting",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "b444594f79844b0d6d76d70fbfb3f7f71728f938",
-        "version" : "1.5.1"
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-macro-testing",
       "state" : {
-        "revision" : "851c8b6bde2000d8051dc9aca1efee04dcc37411",
-        "version" : "0.4.1"
+        "revision" : "20c1a8f3b624fb5d1503eadcaa84743050c350f4",
+        "version" : "0.5.2"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "8ddd519780452729c6634ad6bd0d2595938e9ea3",
-        "version" : "1.16.1"
+        "revision" : "f5bfff796ee8e3bc9a685b7ffba1bf20663eb370",
+        "version" : "1.18.0"
       }
     },
     {
@@ -34,6 +34,15 @@
       "state" : {
         "revision" : "0687f71944021d616d34d922343dcef086855920",
         "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "b444594f79844b0d6d76d70fbfb3f7f71728f938",
+        "version" : "1.5.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -30,7 +30,7 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "0687f71944021d616d34d922343dcef086855920",
         "version" : "600.0.1"

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 
 let package = Package(
     name: "TestDRS",
-    platforms: [.macOS(.v13), .iOS(.v16), .tvOS(.v13), .watchOS(.v6), .macCatalyst(.v13)],
+    platforms: [.macOS(.v13), .iOS(.v15), .tvOS(.v13), .watchOS(.v6), .macCatalyst(.v13)],
     products: [
         .library(
             name: "TestDRS",

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "600.0.1"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.1"),
         .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.5.2"),
         .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.5.1"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-syntax.git", from: "600.0.1"),
         .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.5.2"),
-        .package(url: "https://github.com/pointfreeco/swift-issue-reporting", from: "1.5.1"),
+        .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.5.1"),
     ],
     targets: [
         .macro(
@@ -31,7 +31,7 @@ let package = Package(
             name: "TestDRS",
             dependencies: [
                 "TestDRSMacros",
-                .product(name: "IssueReporting", package: "swift-issue-reporting")
+                .product(name: "IssueReporting", package: "xctest-dynamic-overlay")
             ],
             swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -15,9 +15,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-syntax.git", from: "600.0.1"),
-        .package(url: "https://github.com/pointfreeco/swift-macro-testing", .upToNextMajor(from: "0.4.0")),
-        .package(url: "https://github.com/pointfreeco/swift-issue-reporting", .upToNextMajor(from: "1.2.2")),
-        .package(url: "https://github.com/apple/swift-testing.git", from: "0.10.0"),
+        .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.5.2"),
+        .package(url: "https://github.com/pointfreeco/swift-issue-reporting", from: "1.5.1"),
     ],
     targets: [
         .macro(
@@ -40,7 +39,6 @@ let package = Package(
         .testTarget(
             name: "TestDRSTests",
             dependencies: [
-                .product(name: "Testing", package: "swift-testing"),
                 "TestDRS",
                 "TestDRSMacros",
             ],

--- a/Sources/TestDRS/Macros/ConfirmationOfCallMacro.swift
+++ b/Sources/TestDRS/Macros/ConfirmationOfCallMacro.swift
@@ -16,6 +16,7 @@ import Foundation
 ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
 ///   - timeLimit: The maximum amount of time to wait for confirmation. If the time limit is reached before the first call can be confirmed, a test failure is reported. Defaults to a duration that is effectively infinite.
 /// - Returns: A `FunctionCallConfirmation` that waits for the first matching call. Further calls can be confirmed by calling methods on this confirmation.
+@available(iOS 16.0, *)
 @freestanding(expression)
 @discardableResult
 public macro confirmationOfCall<Input, Output>(
@@ -38,6 +39,7 @@ public macro confirmationOfCall<Input, Output>(
 ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
 ///   - timeLimit: The maximum amount of time to wait for confirmation. If the time limit is reached before the first call can be confirmed, a test failure is reported. Defaults to a duration that is effectively infinite.
 /// - Returns: A `FunctionCallConfirmation` that waits for the first matching call. Further calls can be confirmed by calling methods on this confirmation.
+@available(iOS 16.0, *)
 @freestanding(expression)
 @discardableResult
 public macro confirmationOfCall<each Input: Equatable, Output>(

--- a/Sources/TestDRS/Macros/ExpectationMacros.swift
+++ b/Sources/TestDRS/Macros/ExpectationMacros.swift
@@ -3,6 +3,8 @@
 // Copyright © 2024 Turo Open Source. All rights reserved.
 //
 
+// swiftformat:disable spaceAroundOperators
+
 // MARK: - expectWasCalled
 
 /// Expects that the given function was called.
@@ -11,15 +13,16 @@
 ///   - function: A reference to the function to expect was called.
 ///   - inputType: An optional phantom parameter used to derive the input type of the `function` passed in.
 ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
+///   - mode: The `ExpectedCallMode` to use when verifying fuction calls. Defaults to `exclusive`, where unexpected calls to the function cause a failure.
 /// - Returns: An `ExpectWasCalledResult` containing the matching function calls, or an empty array if no matching call was found.
 @freestanding(expression)
 @discardableResult
 public macro expectWasCalled<Input, Output>(
     _ function: (Input) async throws -> Output,
     taking inputType: Input.Type? = nil,
-    returning outputType: Output.Type? = nil
+    returning outputType: Output.Type? = nil,
+    mode: ExpectedCallMode = .exclusive
 ) -> ExpectWasCalledResult<MatchingAnyAmount, Input, Output> = #externalMacro(module: "TestDRSMacros", type: "ExpectWasCalledMacro")
-
 
 /// Expects that the given function was called with the expected input.
 ///
@@ -27,13 +30,15 @@ public macro expectWasCalled<Input, Output>(
 ///   - function: A reference to the function to expect was called.
 ///   - expectedInput: The expected input parameter(s) for the function.
 ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
+///   - mode: The `ExpectedCallMode` to use when verifying fuction calls. Defaults to `exclusive`, where unexpected calls to the function cause a failure.
 /// - Returns: An `ExpectWasCalledResult` containing the matching function calls, or an empty array if no matching call was found.
 @freestanding(expression)
 @discardableResult
 public macro expectWasCalled<each Input: Equatable, Output>(
     _ function: (repeat each Input) async throws -> Output,
     with expectedInput: repeat each Input,
-    returning outputType: Output.Type? = nil
+    returning outputType: Output.Type? = nil,
+    mode: ExpectedCallMode = .exclusive
 ) -> ExpectWasCalledResult<MatchingAnyAmount, (repeat each Input), Output> = #externalMacro(module: "TestDRSMacros", type: "ExpectWasCalledMacro")
 
 // MARK: - expectWasNotCalled

--- a/Sources/TestDRS/Macros/ExpectationMacros.swift
+++ b/Sources/TestDRS/Macros/ExpectationMacros.swift
@@ -13,7 +13,7 @@
 ///   - function: A reference to the function to expect was called.
 ///   - inputType: An optional phantom parameter used to derive the input type of the `function` passed in.
 ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
-///   - mode: The `ExpectedCallMode` to use when verifying fuction calls. Defaults to `exclusive`, where unexpected calls to the function cause a failure.
+///   - mode: The `ExpectedCallMode` to use when verifying fuction calls. Defaults to `exclusive`, where non-matching calls to the function cause a failure.
 /// - Returns: An `ExpectWasCalledResult` containing the matching function calls, or an empty array if no matching call was found.
 @freestanding(expression)
 @discardableResult
@@ -30,7 +30,7 @@ public macro expectWasCalled<Input, Output>(
 ///   - function: A reference to the function to expect was called.
 ///   - expectedInput: The expected input parameter(s) for the function.
 ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
-///   - mode: The `ExpectedCallMode` to use when verifying fuction calls. Defaults to `exclusive`, where unexpected calls to the function cause a failure.
+///   - mode: The `ExpectedCallMode` to use when verifying fuction calls. Defaults to `exclusive`, where non-matching calls to the function cause a failure.
 /// - Returns: An `ExpectWasCalledResult` containing the matching function calls, or an empty array if no matching call was found.
 @freestanding(expression)
 @discardableResult

--- a/Sources/TestDRS/Spy/Blackbox/BlackBox+Expectations.swift
+++ b/Sources/TestDRS/Spy/Blackbox/BlackBox+Expectations.swift
@@ -35,7 +35,7 @@ extension BlackBox {
                     .filter { !expectedCallIds.contains($0.id) }
                     .map { $0.debugDescription }
                     .joined(separator: "\n")
-                let messaage = "\(signature) was called with input type \(Input.self) and output type \(Output.self), but was also called with other input and/or output types:\n\(unexpectedCalls)"
+                let messaage = "\(signature) was called with input type \(Input.self) and output type \(Output.self), but was also called with other input and/or output types:\n\n\(unexpectedCalls)"
                 reportFailure(messaage, location: location)
             }
         }

--- a/Sources/TestDRS/Spy/Blackbox/BlackBox.swift
+++ b/Sources/TestDRS/Spy/Blackbox/BlackBox.swift
@@ -32,7 +32,7 @@ public final class BlackBox: @unchecked Sendable {
         signature: FunctionSignature
     ) {
         storageQueue.sync {
-            let call =  FunctionCall(
+            let call = FunctionCall(
                 signature: signature,
                 input: input,
                 outputType: outputType,
@@ -40,7 +40,10 @@ public final class BlackBox: @unchecked Sendable {
                 id: self.storage.count + 1
             )
             self.storage.append(call)
-            streamCall(call)
+
+            if #available(iOS 16.0, *) {
+                streamCall(call)
+            }
         }
     }
 
@@ -81,8 +84,12 @@ public final class BlackBox: @unchecked Sendable {
         }
     }
 
+}
 
-    // MARK: - AsyncStream Support
+// MARK: - AsyncStream Support
+
+@available(iOS 16.0, *)
+extension BlackBox {
 
     /// Streams all calls with the given input and output type.
     func streamForCallsMatching<Input, Output>(
@@ -94,6 +101,8 @@ public final class BlackBox: @unchecked Sendable {
             addContinuation(FunctionCallContinuation(wrappedValue: continuation, signature: signature))
         }
     }
+
+    // swiftformat:disable spaceAroundOperators
 
     /// Streams calls with input equal to the expected input and a matching output type.
     func streamForCallsMatching<each Input: Equatable, Output>(
@@ -111,6 +120,8 @@ public final class BlackBox: @unchecked Sendable {
             )
         }
     }
+
+    // swiftformat:enable spaceAroundOperators
 
     private func addContinuation<Input, Output>(_ continuation: any FunctionCallContinuationRepresentation<Input, Output>) {
         storageQueue.sync {
@@ -140,6 +151,7 @@ public final class BlackBox: @unchecked Sendable {
             .compactMap { $0 as? any FunctionCallContinuationRepresentation<Input, Output> }
             .forEach { $0.yield(call) }
     }
+
 }
 
 // MARK: CustomDebugStringConvertible

--- a/Sources/TestDRS/Spy/FunctionCall.swift
+++ b/Sources/TestDRS/Spy/FunctionCall.swift
@@ -56,7 +56,7 @@ public struct FunctionCall<Input, Output>: FunctionCallRepresentation, @unchecke
     public let signature: FunctionSignature
 
     /// The type of the function's input parameter(s) (or `Void` if it does not take any parameters). If a function takes more than one parameter, this will be a tuple with the parameters in the order they appear in the signature.
-    let input: Input
+    public let input: Input
 
     /// The return type of the function.
     let outputType: Output.Type

--- a/Sources/TestDRS/Spy/FunctionCallConfirmation.swift
+++ b/Sources/TestDRS/Spy/FunctionCallConfirmation.swift
@@ -12,6 +12,7 @@ enum FunctionCallConfirmationError: Error {
 
 /// `FunctionCallConfirmation` is a struct that encapsulates the result of a `#confirmationOfCall`.
 /// It contains any calls that match the confirmation and provides methods for confirming the number of times the given call was recorded.
+@available(iOS 16.0, *)
 public struct FunctionCallConfirmation<AmountMatching: FunctionCallAmountMatching, Input, Output>: Sendable {
 
     private var _matchingCalls: [FunctionCall<Input, Output>] = []
@@ -48,6 +49,7 @@ public struct FunctionCallConfirmation<AmountMatching: FunctionCallAmountMatchin
 
 }
 
+@available(iOS 16.0, *)
 extension FunctionCallConfirmation where AmountMatching == MatchingFirst {
 
     static func confirmFirstCall(
@@ -99,6 +101,7 @@ extension FunctionCallConfirmation where AmountMatching == MatchingFirst {
 
 // MARK: - Matching Calls
 
+@available(iOS 16.0, *)
 extension FunctionCallConfirmation where AmountMatching: MatchingSingle {
 
     /// The matching call or `nil` if no calls were made that match the expectation.
@@ -116,6 +119,7 @@ extension FunctionCallConfirmation where AmountMatching: MatchingSingle {
 
 }
 
+@available(iOS 16.0, *)
 extension FunctionCallConfirmation where AmountMatching: MatchingMultiple {
 
     /// The matching calls or an empty array  if no calls were confirmed.
@@ -143,6 +147,7 @@ extension FunctionCallConfirmation where AmountMatching: MatchingMultiple {
 
 // MARK: - Confirming amount
 
+@available(iOS 16.0, *)
 extension FunctionCallConfirmation where AmountMatching == MatchingFirst, Input: Sendable {
 
     /// Makes a further confirmation that the specified call occurred exactly once.

--- a/Sources/TestDRS/Spy/Spy+Confirmations.swift
+++ b/Sources/TestDRS/Spy/Spy+Confirmations.swift
@@ -18,6 +18,7 @@ public extension Spy {
     ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
     ///   - timeLimit: The maximum amount of time to wait for confirmation. If the time limit is reached before the first call can be confirmed, a test failure is reported. Defaults to a duration that is effectively infinite.
     /// - Returns: A `FunctionCallConfirmation` that waits for the first matching call. Further calls can be confirmed by calling methods on this confirmation.
+    @available(iOS 16.0, *)
     @discardableResult
     func confirmationOfCall<Input, Output>(
         to function: (Input) async throws -> Output,
@@ -57,6 +58,7 @@ public extension Spy {
     ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
     ///   - timeLimit: The maximum amount of time to wait for confirmation. If the time limit is reached before the first call can be confirmed, a test failure is reported. Defaults to a duration that is effectively infinite.
     /// - Returns: A `FunctionCallConfirmation` that waits for the first matching call. Further calls can be confirmed by calling methods on this confirmation.
+    @available(iOS 16.0, *)
     @discardableResult
     func confirmationOfCall<each Input: Equatable, Output>(
         to function: (repeat each Input) async throws -> Output,

--- a/Sources/TestDRS/Spy/Spy+Expectations.swift
+++ b/Sources/TestDRS/Spy/Spy+Expectations.swift
@@ -7,6 +7,13 @@ import Foundation
 
 // swiftformat:disable spaceAroundOperators
 
+public enum ExpectedCallMode {
+    /// Calls made to a function other than those expected should cause a failure
+    case exclusive
+    /// Calls made to a function other than those expected should not cause a failure
+    case nonExclusive
+}
+
 // MARK: - Instance methods
 
 /// Extension for `Spy` that provides expectation methods for verifying call counts and call order.
@@ -28,6 +35,7 @@ public extension Spy {
         withSignature signature: FunctionSignature,
         taking inputType: Input.Type? = nil,
         returning outputType: Output.Type? = nil,
+        mode: ExpectedCallMode = .exclusive,
         fileID: StaticString = #fileID,
         filePath: StaticString = #filePath,
         line: UInt = #line,
@@ -37,6 +45,7 @@ public extension Spy {
         return blackBox.expectWasCalled(
             function,
             signature: signature,
+            mode: mode,
             location: location
         )
     }
@@ -57,6 +66,7 @@ public extension Spy {
         withSignature signature: FunctionSignature,
         expectedInput: repeat each Input,
         returning: Output.Type? = nil,
+        mode: ExpectedCallMode = .exclusive,
         fileID: StaticString = #fileID,
         filePath: StaticString = #filePath,
         line: UInt = #line,
@@ -67,6 +77,7 @@ public extension Spy {
             function,
             signature: signature,
             expectedInput: repeat each expectedInput,
+            mode: mode,
             location: location
         )
     }
@@ -123,6 +134,7 @@ public extension Spy {
         withSignature signature: FunctionSignature,
         taking inputType: Input.Type? = nil,
         returning outputType: Output.Type? = nil,
+        mode: ExpectedCallMode = .exclusive,
         fileID: StaticString = #fileID,
         filePath: StaticString = #filePath,
         line: UInt = #line,
@@ -133,6 +145,7 @@ public extension Spy {
             .expectWasCalled(
                 function,
                 signature: signature,
+                mode: mode,
                 location: location
             )
     }
@@ -154,6 +167,7 @@ public extension Spy {
         withSignature signature: FunctionSignature,
         expectedInput: repeat each Input,
         returning: Output.Type? = nil,
+        mode: ExpectedCallMode = .exclusive,
         fileID: StaticString = #fileID,
         filePath: StaticString = #filePath,
         line: UInt = #line,
@@ -165,6 +179,7 @@ public extension Spy {
                 function,
                 signature: signature,
                 expectedInput: repeat each expectedInput,
+                mode: mode,
                 location: location
             )
     }

--- a/Sources/TestDRS/Spy/Spy+Expectations.swift
+++ b/Sources/TestDRS/Spy/Spy+Expectations.swift
@@ -28,6 +28,7 @@ public extension Spy {
     ///   This should also match what is recorded by the `#function` macro.
     ///   - inputType: An optional phantom parameter used to derive the input type of the `function` passed in.
     ///   - outputType: An optional  phantom parameter used to derive the output type of the `function` passed in.
+    ///   - mode: The `ExpectedCallMode` to use when verifying fuction calls. Defaults to `exclusive`, where non-matching calls to the function cause a failure.
     /// - Returns: An `ExpectWasCalledResult` containing the matching function calls, or an empty array if no matching call was found.
     @discardableResult
     func expectWasCalled<Input, Output>(
@@ -59,6 +60,7 @@ public extension Spy {
     ///   This should also match what is recorded by the `#function` macro.
     ///   - expectedInput: The expected input parameter(s) for the function.
     ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
+    ///   - mode: The `ExpectedCallMode` to use when verifying fuction calls. Defaults to `exclusive`, where non-matching calls to the function cause a failure.
     /// - Returns: An `ExpectWasCalledResult` containing the matching function calls, or an empty array if no matching call was found.
     @discardableResult
     func expectWasCalled<each Input: Equatable, Output>(
@@ -127,6 +129,7 @@ public extension Spy {
     ///   This should also match what is recorded by the `#function` macro.
     ///   - inputType: An optional phantom parameter used to derive the input type of the `function` passed in.
     ///   - outputType: An optional  phantom parameter used to derive the output type of the `function` passed in.
+    ///   - mode: The `ExpectedCallMode` to use when verifying fuction calls. Defaults to `exclusive`, where non-matching calls to the function cause a failure.
     /// - Returns: An `ExpectWasCalledResult` containing the matching function calls, or an empty array if no matching call was found.
     @discardableResult
     static func expectStaticFunctionWasCalled<Input, Output>(
@@ -159,7 +162,7 @@ public extension Spy {
     ///   This should also match what is recorded by the `#function` macro.
     ///   - expectedInput: The expected input parameter(s) for the function.
     ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
-    ///   - reportFailure: A function that handles reporting any test failures.
+    ///   - mode: The `ExpectedCallMode` to use when verifying fuction calls. Defaults to `exclusive`, where non-matching calls to the function cause a failure.
     /// - Returns: An `ExpectWasCalledResult` containing the matching function calls, or an empty array if no matching call was found.
     @discardableResult
     static func expectStaticFunctionWasCalled<each Input: Equatable, Output>(
@@ -193,7 +196,6 @@ public extension Spy {
     ///   This should also match what is recorded by the `#function` macro.
     ///   - inputType: An optional phantom parameter used to derive the input type of the `function` passed in.
     ///   - outputType: An optional  phantom parameter used to derive the output type of the `function` passed in.
-    ///   - reportFailure: A function that handles reporting any test failures.
     static func expectStaticFunctionWasNotCalled<Input, Output>(
         _ function: (Input) async throws -> Output,
         withSignature signature: FunctionSignature,

--- a/Sources/TestDRS/Spy/Spy+Expectations.swift
+++ b/Sources/TestDRS/Spy/Spy+Expectations.swift
@@ -200,6 +200,7 @@ public extension Spy {
 
 }
 
+@available(iOS 16.0, *)
 extension Duration {
     /// A duration that is long enough to essentially be considered infinite, but short enough to not cause an error when used to sleep a `Task`.
     public static let maxTimeLimit = Duration.seconds(Int32.max)

--- a/Sources/TestDRSMacros/Stubbing/StubMacroExpansion.swift
+++ b/Sources/TestDRSMacros/Stubbing/StubMacroExpansion.swift
@@ -40,7 +40,7 @@ public struct SetStubReturningOutputMacro: ExpressionMacro {
             """
         } else if let expression = firstArgument.as(DeclReferenceExprSyntax.self) {
             return """
-            setStub(for: \(expression), withSignature: "\(expression.argumentNames == nil ? "\(expression)()" : "\(expression)")", taking: \(inputType == nil ? "nil" : "\(inputType)"), returning: \(output))
+            setStub(for: \(expression), withSignature: "\(expression)", taking: \(inputType == nil ? "nil" : "\(inputType)"), returning: \(output))
             """
         } else {
             context.diagnose(
@@ -85,7 +85,7 @@ public struct SetStubThrowingErrorMacro: ExpressionMacro {
             """
         } else if let expression = firstArgument.as(DeclReferenceExprSyntax.self) {
             return """
-            setStub(for: \(expression), withSignature: "\(expression.argumentNames == nil ? "\(expression)()" : "\(expression)")", taking: \(inputType == nil ? "nil" : "\(inputType)"), throwing: \(error))
+            setStub(for: \(expression), withSignature: "\(expression)", taking: \(inputType == nil ? "nil" : "\(inputType)"), throwing: \(error))
             """
         } else {
             context.diagnose(
@@ -126,7 +126,7 @@ public struct SetStubUsingClosureMacro: ExpressionMacro {
             """
         } else if let expression = firstArgument.as(DeclReferenceExprSyntax.self) {
             return """
-            setDynamicStub(for: \(expression), withSignature: "\(expression.argumentNames == nil ? "\(expression)()" : "\(expression)")")\(closure)
+            setDynamicStub(for: \(expression), withSignature: "\(expression)")\(closure)
             """
         } else {
             context.diagnose(

--- a/Tests/TestDRSMacrosTests/Stubbing/SetStubReturningOutputMacroExpansionTests.swift
+++ b/Tests/TestDRSMacrosTests/Stubbing/SetStubReturningOutputMacroExpansionTests.swift
@@ -48,7 +48,7 @@ final class SetStubReturningOutputMacroTests: XCTestCase {
             """
         } expansion: {
             """
-            setStub(for: foo, withSignature: "foo()", taking: nil, returning: "Hello World")
+            setStub(for: foo, withSignature: "foo", taking: nil, returning: "Hello World")
             """
         }
     }
@@ -72,7 +72,7 @@ final class SetStubReturningOutputMacroTests: XCTestCase {
             """
         } expansion: {
             """
-            setStub(for: foo, withSignature: "foo()", taking: Int.self, returning: "Hello World")
+            setStub(for: foo, withSignature: "foo", taking: Int.self, returning: "Hello World")
             """
         }
     }

--- a/Tests/TestDRSMacrosTests/Stubbing/SetStubThrowingErrorMacroExpansionTests.swift
+++ b/Tests/TestDRSMacrosTests/Stubbing/SetStubThrowingErrorMacroExpansionTests.swift
@@ -48,7 +48,7 @@ final class SetStubThrowingErrorMacroExpansionTests: XCTestCase {
             """
         } expansion: {
             """
-            setStub(for: foo, withSignature: "foo()", taking: nil, throwing: MyError.someError)
+            setStub(for: foo, withSignature: "foo", taking: nil, throwing: MyError.someError)
             """
         }
     }
@@ -72,7 +72,7 @@ final class SetStubThrowingErrorMacroExpansionTests: XCTestCase {
             """
         } expansion: {
             """
-            setStub(for: foo, withSignature: "foo()", taking: Int.self, throwing: MyError.someError)
+            setStub(for: foo, withSignature: "foo", taking: Int.self, throwing: MyError.someError)
             """
         }
     }

--- a/Tests/TestDRSMacrosTests/Stubbing/SetStubUsingClosureMacroExpansionTests.swift
+++ b/Tests/TestDRSMacrosTests/Stubbing/SetStubUsingClosureMacroExpansionTests.swift
@@ -56,7 +56,7 @@ final class SetStubUsingClosureMacroExpansionTests: XCTestCase {
             """
         } expansion: {
             """
-            setDynamicStub(for: foo, withSignature: "foo()") {
+            setDynamicStub(for: foo, withSignature: "foo") {
                 "Hello World"
             }
             """

--- a/Tests/TestDRSTests/Integration/ParameterProtocolTests.swift
+++ b/Tests/TestDRSTests/Integration/ParameterProtocolTests.swift
@@ -1,0 +1,52 @@
+//
+// Created on 1/27/25.
+// Copyright © 2025 Turo Open Source. All rights reserved.
+//
+
+import TestDRS
+import Testing
+
+/// Tests for verifying behavior when the input to a method uses a parameter constrained to a protocol,
+/// but the function itself is not generic over that parameter.
+struct ProtocolConstrainedNonGenericParameterTests {
+
+    @Test
+    func testWithSingleProtocolConstrainedParameter() {
+        let myMock = MyMock()
+        let parameter = ParamStruct()
+
+        // Since foo isn't generic over `ParamProtocol`, the input will be recorded as a `ParamProtocol` and not a `ParamStruct`
+        myMock.foo(paramOne: parameter)
+
+        // Without specifying the input type, it resolves to `ParamProtocol`
+        #expectWasCalled(myMock.foo)
+
+        // When the input type is specified as `ParamStruct`, the expectation can be checked with the concrete type
+        #expectWasCalled(myMock.foo, taking: ParamStruct.self)
+
+        // When the expected input is specified, again the expectation can be checked with the concrete type
+        #expectWasCalled(myMock.foo, with: parameter)
+    }
+
+    @Test
+    func testWithMultipleProtocolConstrainedParameters() {
+        let myMock = MyMock()
+        let parameter = ParamStruct()
+
+        myMock.bar(paramOne: parameter, paramTwo: parameter)
+
+        #expectWasCalled(myMock.bar)
+        #expectWasCalled(myMock.bar, taking: (ParamStruct, ParamStruct).self)
+        #expectWasCalled(myMock.bar, with: parameter, parameter)
+    }
+
+}
+
+private protocol ParamProtocol {}
+private struct ParamStruct: ParamProtocol, Equatable {}
+
+@Mock
+private struct MyMock {
+    fileprivate func foo(paramOne: ParamProtocol)
+    fileprivate func bar(paramOne: ParamProtocol, paramTwo: ParamProtocol)
+}

--- a/Tests/TestDRSTests/Spy/ConfirmationOfCallMacroTests.swift
+++ b/Tests/TestDRSTests/Spy/ConfirmationOfCallMacroTests.swift
@@ -100,7 +100,7 @@ struct ConfirmationOfCallMacroTests: Sendable {
             issue.sourceLocation?.line == #line - 2 &&
                 issue.sourceLocation?.fileID == #fileID &&
                 issue.description == """
-                Expectation failed: No calls to "foo" with input type () and output type () were recorded
+                Issue recorded: No calls to "foo" with input type () and output type () were recorded
                 """
         }
     }
@@ -157,7 +157,7 @@ struct ConfirmationOfCallMacroTests: Sendable {
                 issue.sourceLocation?.line == #line - 2 &&
                     issue.sourceLocation?.fileID == #fileID &&
                     issue.description == """
-                    Expectation failed: Expected \"rab\" to be called exactly once as specified, but an additional call was recorded
+                    Issue recorded: Expected \"rab\" to be called exactly once as specified, but an additional call was recorded
                     """
             }
         }
@@ -182,7 +182,7 @@ struct ConfirmationOfCallMacroTests: Sendable {
             issue.sourceLocation?.line == #line - 2 &&
                 issue.sourceLocation?.fileID == #fileID &&
                 issue.description == """
-                Expectation failed: Expected "rab" to be called as specified 2 times, but only 1 calls were recorded before timing out
+                Issue recorded: Expected "rab" to be called as specified 2 times, but only 1 calls were recorded before timing out
                 """
         }
     }
@@ -222,7 +222,7 @@ struct ConfirmationOfCallMacroTests: Sendable {
                 issue.sourceLocation?.line == #line - 2 &&
                     issue.sourceLocation?.fileID == #fileID &&
                     issue.description == """
-                    Expectation failed: Expected "rab" to be called as specified 2 times, but an additional call was recorded
+                    Issue recorded: Expected "rab" to be called as specified 2 times, but an additional call was recorded
                     """
             }
         }
@@ -247,7 +247,7 @@ struct ConfirmationOfCallMacroTests: Sendable {
             issue.sourceLocation?.line == #line - 2 &&
                 issue.sourceLocation?.fileID == #fileID &&
                 issue.description == """
-                Expectation failed: Expected "rab" to be called as specified at least 2 times, but only 1 calls were recorded before timing out
+                Issue recorded: Expected "rab" to be called as specified at least 2 times, but only 1 calls were recorded before timing out
                 """
         }
 
@@ -262,7 +262,7 @@ struct ConfirmationOfCallMacroTests: Sendable {
             issue.sourceLocation?.line == #line - 2 &&
                 issue.sourceLocation?.fileID == #fileID &&
                 issue.description == """
-                Expectation failed: Expected "rab" to be called as specified at least 2 times, but only 1 calls were recorded before timing out
+                Issue recorded: Expected "rab" to be called as specified at least 2 times, but only 1 calls were recorded before timing out
                 """
         }
 
@@ -277,7 +277,7 @@ struct ConfirmationOfCallMacroTests: Sendable {
             issue.sourceLocation?.line == #line - 2 &&
                 issue.sourceLocation?.fileID == #fileID &&
                 issue.description == """
-                Expectation failed: Expected "rab" to be called as specified at least 2 times, but only 1 calls were recorded before timing out
+                Issue recorded: Expected "rab" to be called as specified at least 2 times, but only 1 calls were recorded before timing out
                 """
         }
     }
@@ -320,7 +320,7 @@ struct ConfirmationOfCallMacroTests: Sendable {
                 issue.sourceLocation?.line == #line - 2 &&
                     issue.sourceLocation?.fileID == #fileID &&
                     issue.description == """
-                    Expectation failed: Expected "rab" to be called as specified within 2...4 times, but an additional call was recorded
+                    Issue recorded: Expected "rab" to be called as specified within 2...4 times, but an additional call was recorded
                     """
             }
 
@@ -335,7 +335,7 @@ struct ConfirmationOfCallMacroTests: Sendable {
                 issue.sourceLocation?.line == #line - 2 &&
                     issue.sourceLocation?.fileID == #fileID &&
                     issue.description == """
-                    Expectation failed: Expected "rab" to be called as specified within 2..<5 times, but an additional call was recorded
+                    Issue recorded: Expected "rab" to be called as specified within 2..<5 times, but an additional call was recorded
                     """
             }
         }

--- a/Tests/TestDRSTests/Spy/ExpectWasCalledResultTests.swift
+++ b/Tests/TestDRSTests/Spy/ExpectWasCalledResultTests.swift
@@ -219,14 +219,29 @@ final class ExpectWasCalledResultTests: XCTestCase {
         spy.zab(paramOne: 2)
         spy.zab(paramOne: 3)
 
-        spy.expectWasCalled(spy.zab(paramOne:), withSignature: "zab(paramOne:)", taking: Bool.self).occurring(times: 1)
-        spy.expectWasCalled(spy.zab(paramOne:), withSignature: "zab(paramOne:)", taking: String.self).occurring(times: 2)
-        spy.expectWasCalled(spy.zab(paramOne:), withSignature: "zab(paramOne:)", taking: Int.self).occurring(times: 3)
+        spy.expectWasCalled(
+            spy.zab(paramOne:),
+            withSignature: "zab(paramOne:)",
+            taking: Bool.self,
+            mode: .nonExclusive
+        ).occurring(times: 1)
+        spy.expectWasCalled(
+            spy.zab(paramOne:),
+            withSignature: "zab(paramOne:)",
+            taking: String.self,
+            mode: .nonExclusive
+        ).occurring(times: 2)
+        spy.expectWasCalled(
+            spy.zab(paramOne:),
+            withSignature: "zab(paramOne:)",
+            taking: Int.self,
+            mode: .nonExclusive
+        ).occurring(times: 3)
 
         XCTExpectFailure(
             failingBlock: {
                 line = #line + 2
-                spy.expectWasCalled(spy.zab(paramOne:), withSignature: "zab(paramOne:)", taking: Bool.self)
+                spy.expectWasCalled(spy.zab(paramOne:), withSignature: "zab(paramOne:)", taking: Bool.self, mode: .nonExclusive)
                     .occurring(times: 4)
             },
             issueMatcher: { issue in

--- a/Tests/TestDRSTests/Spy/ExpectationMacroTests.swift
+++ b/Tests/TestDRSTests/Spy/ExpectationMacroTests.swift
@@ -29,46 +29,63 @@ final class ExpectationMacroTests: XCTestCase {
     func testExpectWasCalled_WithDifferentParameterTypes() {
         spy.zab(paramOne: true)
         spy.zab(paramOne: "Hello")
+
+        XCTExpectFailure { [weak self] in
+            guard let self else { return }
+
+            #expectWasCalled(spy.zab(paramOne:), with: true)
+        }
+
+        XCTExpectFailure { [weak self] in
+            guard let self else { return }
+
+            #expectWasCalled(spy.zab(paramOne:), with: "Hello")
+        }
+    }
+
+    func testExpectWasCalled_WithDifferentParameterTypes_NonExclusiveMode() {
+        spy.zab(paramOne: true)
+        spy.zab(paramOne: "Hello")
         spy.zab(paramOne: "World")
         spy.zab(paramOne: 1)
         spy.zab(paramOne: 2)
         spy.zab(paramOne: 3)
 
-        #expectWasCalled(spy.zab(paramOne:), with: true)
-        #expectWasCalled(spy.zab(paramOne:), with: "Hello")
-        #expectWasCalled(spy.zab(paramOne:), with: "World")
-        #expectWasCalled(spy.zab(paramOne:), with: 1)
-        #expectWasCalled(spy.zab(paramOne:), with: 2)
-        #expectWasCalled(spy.zab(paramOne:), with: 3)
+        #expectWasCalled(spy.zab(paramOne:), with: true, mode: .nonExclusive)
+        #expectWasCalled(spy.zab(paramOne:), with: "Hello", mode: .nonExclusive)
+        #expectWasCalled(spy.zab(paramOne:), with: "World", mode: .nonExclusive)
+        #expectWasCalled(spy.zab(paramOne:), with: 1, mode: .nonExclusive)
+        #expectWasCalled(spy.zab(paramOne:), with: 2, mode: .nonExclusive)
+        #expectWasCalled(spy.zab(paramOne:), with: 3, mode: .nonExclusive)
 
         XCTExpectFailure { [weak self] in
             guard let self else { return }
 
-            #expectWasCalled(spy.zab(paramOne:), taking: Double.self)
+            #expectWasCalled(spy.zab(paramOne:), taking: Double.self, mode: .nonExclusive)
         }
 
         XCTExpectFailure { [weak self] in
             guard let self else { return }
 
-            #expectWasCalled(spy.zab(paramOne:), with: 1.0)
+            #expectWasCalled(spy.zab(paramOne:), with: 1.0, mode: .nonExclusive)
         }
 
         XCTExpectFailure { [weak self] in
             guard let self else { return }
 
-            #expectWasCalled(spy.zab(paramOne:), with: false)
+            #expectWasCalled(spy.zab(paramOne:), with: false, mode: .nonExclusive)
         }
 
         XCTExpectFailure { [weak self] in
             guard let self else { return }
 
-            #expectWasCalled(spy.zab(paramOne:), with: "Goodbye")
+            #expectWasCalled(spy.zab(paramOne:), with: "Goodbye", mode: .nonExclusive)
         }
 
         XCTExpectFailure { [weak self] in
             guard let self else { return }
 
-            #expectWasCalled(spy.zab(paramOne:), with: 4)
+            #expectWasCalled(spy.zab(paramOne:), with: 4, mode: .nonExclusive)
         }
     }
 
@@ -76,19 +93,52 @@ final class ExpectationMacroTests: XCTestCase {
         spy.rab(paramOne: true, paramTwo: 1, paramThree: "Hello")
         spy.rab(paramOne: false, paramTwo: nil, paramThree: nil)
 
-        #expectWasCalled(spy.rab(paramOne:paramTwo:paramThree:), with: true, 1, "Hello")
-        #expectWasCalled(spy.rab(paramOne:paramTwo:paramThree:), with: false, Int?.none, String?.none)
-
         XCTExpectFailure { [weak self] in
             guard let self else { return }
 
-            #expectWasCalled(spy.rab(paramOne:paramTwo:paramThree:), with: true, 2, "Hello")
+            #expectWasCalled(spy.rab(paramOne:paramTwo:paramThree:), with: true, 1, "Hello")
         }
 
         XCTExpectFailure { [weak self] in
             guard let self else { return }
 
-            #expectWasCalled(spy.rab(paramOne:paramTwo:paramThree:), with: true, Int?.none, String?.none)
+            #expectWasCalled(spy.rab(paramOne:paramTwo:paramThree:), with: false, nil, nil)
+        }
+    }
+
+    func testExpectWasCalled_WithMultipleParameters_NonExclusiveMode() {
+        spy.rab(paramOne: true, paramTwo: 1, paramThree: "Hello")
+        spy.rab(paramOne: false, paramTwo: nil, paramThree: nil)
+
+        #expectWasCalled(
+            spy.rab(paramOne:paramTwo:paramThree:),
+            with: true, 1, "Hello",
+            mode: .nonExclusive
+        )
+        #expectWasCalled(
+            spy.rab(paramOne:paramTwo:paramThree:),
+            with: false, Int?.none, String?.none,
+            mode: .nonExclusive
+        )
+
+        XCTExpectFailure { [weak self] in
+            guard let self else { return }
+
+            #expectWasCalled(
+                spy.rab(paramOne:paramTwo:paramThree:),
+                with: true, 2, "Hello",
+                mode: .nonExclusive
+            )
+        }
+
+        XCTExpectFailure { [weak self] in
+            guard let self else { return }
+
+            #expectWasCalled(
+                spy.rab(paramOne:paramTwo:paramThree:),
+                with: true, Int?.none, String?.none,
+                mode: .nonExclusive
+            )
         }
     }
 

--- a/Tests/TestDRSTests/Spy/FunctionCallConfirmationTests.swift
+++ b/Tests/TestDRSTests/Spy/FunctionCallConfirmationTests.swift
@@ -128,7 +128,7 @@ struct FunctionCallConfirmationSwiftTesting: Sendable {
             issue.sourceLocation?.line == #line - 6 &&
                 issue.sourceLocation?.fileID == #fileID &&
                 issue.description == """
-                Expectation failed: No calls to "foo()" with input type () and output type () were recorded
+                Issue recorded: No calls to "foo()" with input type () and output type () were recorded
                 """
         }
     }
@@ -196,7 +196,7 @@ struct FunctionCallConfirmationSwiftTesting: Sendable {
                 issue.sourceLocation?.line == #line - 2 &&
                     issue.sourceLocation?.fileID == #fileID &&
                     issue.description == """
-                    Expectation failed: Expected \"rab(paramOne:paramTwo:paramThree:)\" to be called exactly once as specified, but an additional call was recorded
+                    Issue recorded: Expected \"rab(paramOne:paramTwo:paramThree:)\" to be called exactly once as specified, but an additional call was recorded
                     """
             }
         }
@@ -222,7 +222,7 @@ struct FunctionCallConfirmationSwiftTesting: Sendable {
             issue.sourceLocation?.line == #line - 2 &&
                 issue.sourceLocation?.fileID == #fileID &&
                 issue.description == """
-                Expectation failed: Expected "rab(paramOne:paramTwo:paramThree:)" to be called as specified 2 times, but only 1 calls were recorded before timing out
+                Issue recorded: Expected "rab(paramOne:paramTwo:paramThree:)" to be called as specified 2 times, but only 1 calls were recorded before timing out
                 """
         }
     }
@@ -264,7 +264,7 @@ struct FunctionCallConfirmationSwiftTesting: Sendable {
                 issue.sourceLocation?.line == #line - 2 &&
                     issue.sourceLocation?.fileID == #fileID &&
                     issue.description == """
-                    Expectation failed: Expected "rab(paramOne:paramTwo:paramThree:)" to be called as specified 2 times, but an additional call was recorded
+                    Issue recorded: Expected "rab(paramOne:paramTwo:paramThree:)" to be called as specified 2 times, but an additional call was recorded
                     """
             }
         }
@@ -290,7 +290,7 @@ struct FunctionCallConfirmationSwiftTesting: Sendable {
             issue.sourceLocation?.line == #line - 2 &&
                 issue.sourceLocation?.fileID == #fileID &&
                 issue.description == """
-                Expectation failed: Expected "rab(paramOne:paramTwo:paramThree:)" to be called as specified at least 2 times, but only 1 calls were recorded before timing out
+                Issue recorded: Expected "rab(paramOne:paramTwo:paramThree:)" to be called as specified at least 2 times, but only 1 calls were recorded before timing out
                 """
         }
 
@@ -306,7 +306,7 @@ struct FunctionCallConfirmationSwiftTesting: Sendable {
             issue.sourceLocation?.line == #line - 2 &&
                 issue.sourceLocation?.fileID == #fileID &&
                 issue.description == """
-                Expectation failed: Expected "rab(paramOne:paramTwo:paramThree:)" to be called as specified at least 2 times, but only 1 calls were recorded before timing out
+                Issue recorded: Expected "rab(paramOne:paramTwo:paramThree:)" to be called as specified at least 2 times, but only 1 calls were recorded before timing out
                 """
         }
 
@@ -322,7 +322,7 @@ struct FunctionCallConfirmationSwiftTesting: Sendable {
             issue.sourceLocation?.line == #line - 2 &&
                 issue.sourceLocation?.fileID == #fileID &&
                 issue.description == """
-                Expectation failed: Expected "rab(paramOne:paramTwo:paramThree:)" to be called as specified at least 2 times, but only 1 calls were recorded before timing out
+                Issue recorded: Expected "rab(paramOne:paramTwo:paramThree:)" to be called as specified at least 2 times, but only 1 calls were recorded before timing out
                 """
         }
     }
@@ -367,7 +367,7 @@ struct FunctionCallConfirmationSwiftTesting: Sendable {
                 issue.sourceLocation?.line == #line - 2 &&
                     issue.sourceLocation?.fileID == #fileID &&
                     issue.description == """
-                    Expectation failed: Expected "rab(paramOne:paramTwo:paramThree:)" to be called as specified within 2...4 times, but an additional call was recorded
+                    Issue recorded: Expected "rab(paramOne:paramTwo:paramThree:)" to be called as specified within 2...4 times, but an additional call was recorded
                     """
             }
 
@@ -383,7 +383,7 @@ struct FunctionCallConfirmationSwiftTesting: Sendable {
                 issue.sourceLocation?.line == #line - 2 &&
                     issue.sourceLocation?.fileID == #fileID &&
                     issue.description == """
-                    Expectation failed: Expected "rab(paramOne:paramTwo:paramThree:)" to be called as specified within 2..<5 times, but an additional call was recorded
+                    Issue recorded: Expected "rab(paramOne:paramTwo:paramThree:)" to be called as specified within 2..<5 times, but an additional call was recorded
                     """
             }
         }


### PR DESCRIPTION
This PR addresses some issue I encountered when integrating with our app:

- Some functionality around confirmations needed to be gated to iOS 16
- There was a deadlock that could occur when evaluating stubs that used closures
- Abbreviated stub signatures were not matching correctly
- Checking calls to a function with protocol constrained parameters did not work properly

It also adds one new feature, which I think is necessary to avoid missing bugs code when testing due to expectations being too specific, and not precluding calls to a function that aren't expected. An `ExpectedCallMode` is added to the function call expectations, which defaults to `exclusive`. This means that if the function is called in a way other than described by the expectation, the expectation fails, even if the expectation was also called in the way expected. This could be due to an additional call with a different input, or a different return type. Any call to the function that is not matched by the expectation will cause a failure.

I could split this out into a separate PR if desired since it wasn't strictly an integration fix, just something I noticed in use.