### PR TITLE
Bump to Swift 6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import CompilerPluginSupport
@@ -55,5 +55,6 @@ let package = Package(
             ],
             swiftSettings: [.enableExperimentalFeature("StrictConcurrency")]
         ),
-    ]
+    ],
+    swiftLanguageModes: [.v6]
 )

--- a/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionClassTests.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionClassTests.swift
@@ -784,5 +784,41 @@ final class AddMockMacroExpansionClassTests: AddMockMacroExpansionTestCase {
         }
     }
 
+    func testUncheckedSendableClass() {
+        assertMacro {
+            """
+            @AddMock
+            class SomeClass: NSObject, @unchecked Sendable {
+                let x = 0
+            }
+            """
+        } expansion: {
+            """
+            class SomeClass: NSObject, @unchecked Sendable {
+                let x = 0
+            }
+
+            #if DEBUG
+
+            final class MockSomeClass: SomeClass, Mock, @unchecked Sendable {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                override var x {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+            }
+
+            #endif
+            """
+        }
+    }
+
 }
 #endif


### PR DESCRIPTION
@nickm01 asked if I could use Swift 6 for TestDRS, so I've gone ahead and done that. I do have one warning in generated mock code that I need to fix before this gets merged, but other than that we are warning and error free.