### PR TITLE
@AddMock macro updates

### DIFF
--- a/Sources/TestDRS/Macros/AddMockMacro.swift
+++ b/Sources/TestDRS/Macros/AddMockMacro.swift
@@ -27,8 +27,6 @@
 /// - Class mocks do not include initializers, as they use the parent class initializers
 /// - Note: None of the initializers, including inherited ones, will automatically stub any properties. Properties must be stubbed manually after initialization.
 ///
-/// The mock is only generated in debug builds and will be enclosed in `#if DEBUG` / `#endif` tags.
-///
 /// Usage:
 /// ```
 /// @AddMock

--- a/Sources/TestDRS/Macros/AddMockMacro.swift
+++ b/Sources/TestDRS/Macros/AddMockMacro.swift
@@ -7,11 +7,27 @@
 ///
 /// The generated mock type includes methods that mimic the original type's interface, allowing you to control its behavior in tests.
 /// For a given type `MyType`, the generated mock type will be named `MockMyType`.
-/// The mock type will conform to the `StubProviding` and `Spy` protocols. This allows you to stub out each method and expect that methods were called in your tests.
-/// Classes will be mocked using a subclass, while protocols and structs will be mocked using a separate class.
-/// Private members are not included in the generated mock type.
+/// The mock type will conform to the `Mock` protocol, which provides stubbing and verification capabilities.
 ///
-/// Mocked classes will override all internal, public and open instance and class members, including methods, properties, and initializers. Overridden initializers will set stubs in the mock for properties that are passed in. Static members of a class will not be included in the generated mock type as they cannot be overridden.
+/// ## Mock Generation Rules:
+/// - Classes will be mocked using a subclass
+/// - Protocols and structs will be mocked using a separate class/struct
+/// - Private members are not included in the generated mock type
+/// - Final classes cannot be mocked (as they cannot be subclassed)
+/// - Final members of a class cannot be mocked (as they cannot be overridden)
+///
+/// ## Member Handling:
+/// - Mocked classes will override all non-private, non-final instance members
+/// - Static members of a class will not be included in the mock as they cannot be overridden
+/// - Protocol and struct mocks will include all non-private members
+///
+/// ## Initializer Handling:
+/// - For protocols and structs, an empty initializer (`init()`) is always provided
+/// - Any non-empty initializers from the original type are included but marked as deprecated to encourage using the empty initializer
+/// - Class mocks do not include initializers, as they use the parent class initializers
+/// - Note: None of the initializers, including inherited ones, will automatically stub any properties. Properties must be stubbed manually after initialization.
+///
+/// The mock is only generated in debug builds and will be enclosed in `#if DEBUG` / `#endif` tags.
 ///
 /// Usage:
 /// ```

--- a/Sources/TestDRSMacros/SyntaxExtensions/AttributeSyntax+Additions.swift
+++ b/Sources/TestDRSMacros/SyntaxExtensions/AttributeSyntax+Additions.swift
@@ -1,0 +1,31 @@
+//
+// Created on 3/6/25.
+// Copyright © 2025 Turo Open Source. All rights reserved.
+//
+
+import SwiftSyntax
+
+extension AttributeSyntax {
+    static func deprecated(message: String) -> AttributeSyntax {
+        AttributeSyntax(
+            atSign: .atSignToken(),
+            attributeName: IdentifierTypeSyntax(name: .identifier("available")),
+            leftParen: .leftParenToken(),
+            arguments: AttributeSyntax.Arguments(
+                LabeledExprListSyntax {
+                    LabeledExprSyntax(
+                        expression: DeclReferenceExprSyntax(baseName: .identifier("*"))
+                    )
+                    LabeledExprSyntax(
+                        expression: DeclReferenceExprSyntax(baseName: .keyword(.deprecated))
+                    )
+                    LabeledExprSyntax(
+                        label: "message",
+                        expression: StringLiteralExprSyntax(content: message)
+                    )
+                }
+            ),
+            rightParen: .rightParenToken()
+        )
+    }
+}

--- a/Sources/TestDRSMacros/SyntaxExtensions/DeclModifierSyntax+Additions.swift
+++ b/Sources/TestDRSMacros/SyntaxExtensions/DeclModifierSyntax+Additions.swift
@@ -1,0 +1,12 @@
+//
+// Created on 3/6/25.
+// Copyright © 2025 Turo Open Source. All rights reserved.
+//
+
+import SwiftSyntax
+
+extension DeclModifierSyntax {
+    static let publicModifier = DeclModifierSyntax(name: .keyword(.public))
+    static let overrideModifier = DeclModifierSyntax(name: .keyword(.override))
+    static let finalModifier = DeclModifierSyntax(name: .keyword(.final))
+}

--- a/Sources/TestDRSMacros/SyntaxExtensions/WithModifiersSyntax+Additions.swift
+++ b/Sources/TestDRSMacros/SyntaxExtensions/WithModifiersSyntax+Additions.swift
@@ -11,6 +11,10 @@ extension WithModifiersSyntax {
         modifiers.containsKeyword(.override)
     }
 
+    var isPublic: Bool {
+        modifiers.containsKeyword(.public)
+    }
+
     var isPrivate: Bool {
         modifiers.containsKeyword(.private)
     }
@@ -25,6 +29,10 @@ extension WithModifiersSyntax {
 
     var isFinal: Bool {
         modifiers.containsKeyword(.final)
+    }
+
+    var hasExplicitAccessControl: Bool {
+        modifiers.containsKeyword(.private) || modifiers.containsKeyword(.fileprivate) || modifiers.containsKeyword(.internal) || modifiers.containsKeyword(.public)
     }
 
 }

--- a/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionClassTests.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionClassTests.swift
@@ -544,13 +544,6 @@ final class AddMockMacroExpansionClassTests: AddMockMacroExpansionTestCase {
                     }
                 }
 
-                override init(_ x: String, y: Int, andZ z: Bool) {
-                    super.init(x, y: y, andZ: z)
-                    self.x = x
-                    self.y = y
-                    myZ = z
-                }
-
                 override func foo() {
                     recordCall()
                     return stubOutput()
@@ -638,13 +631,6 @@ final class AddMockMacroExpansionClassTests: AddMockMacroExpansionTestCase {
                         setStub(value: newValue)
                     }
                 }
-
-                override init(x: String, y: Int, z: Bool) {
-                    super.init(x: x, y: y, z: z)
-                    self.x = x
-                    self.y = y
-                    self.z = z
-                }
             }
 
             #endif
@@ -719,6 +705,74 @@ final class AddMockMacroExpansionClassTests: AddMockMacroExpansionTestCase {
                 let stubRegistry = StubRegistry()
 
                 override func foo() {
+                    recordCall()
+                    return stubOutput()
+                }
+
+            }
+
+            #endif
+            """
+        }
+    }
+
+    func testPublicClass() {
+        assertMacro {
+            """
+            @AddMock
+            public class SomeClass {
+                var x = "Hello World"
+                private var y = 0
+                public var z = true
+
+                func foo() {}
+                private func bar() {}
+                public func baz() {}
+            }
+            """
+        } expansion: {
+            """
+            public class SomeClass {
+                var x = "Hello World"
+                private var y = 0
+                public var z = true
+
+                func foo() {}
+                private func bar() {}
+                public func baz() {}
+            }
+
+            #if DEBUG
+
+            final
+            public class MockSomeClass: SomeClass, Mock {
+
+                public let blackBox = BlackBox()
+                public let stubRegistry = StubRegistry()
+
+                override var x {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                public override var z {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+
+                override func foo() {
+                    recordCall()
+                    return stubOutput()
+                }
+
+                public override func baz() {
                     recordCall()
                     return stubOutput()
                 }

--- a/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionProtocolTests.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionProtocolTests.swift
@@ -282,6 +282,66 @@ final class AddMockMacroExpansionProtocolTests: AddMockMacroExpansionTestCase {
         }
     }
 
+    func testPublicProtocol() {
+        assertMacro {
+            """
+            @AddMock
+            public protocol SomeProtocol {
+                var x: String
+                func foo() throws -> String
+                mutating func bar(paramOne: Bool)
+                init(x: String)
+            }
+            """
+        } expansion: {
+            """
+            public protocol SomeProtocol {
+                var x: String
+                func foo() throws -> String
+                mutating func bar(paramOne: Bool)
+                init(x: String)
+            }
+
+            #if DEBUG
+
+            final
+            public class MockSomeProtocol: SomeProtocol, Mock {
+
+                public let blackBox = BlackBox()
+                public let stubRegistry = StubRegistry()
+
+                public var x: String {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+
+                init() {
+                }
+
+                @available(*, deprecated, message: "Use init() instead to initialize a mock") public init(x: String) {
+                }
+
+                public func foo() throws -> String {
+                    recordCall(returning: String.self)
+                    return try throwingStubOutput()
+                }
+
+                public func bar(paramOne: Bool) {
+                    recordCall(with: paramOne)
+                    return stubOutput(for: paramOne)
+                }
+
+            }
+
+            #endif
+            """
+        }
+    }
+
 }
 
 #endif

--- a/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionStructTests.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionStructTests.swift
@@ -640,6 +640,12 @@ final class AddMockMacroExpansionStructTests: AddMockMacroExpansionTestCase {
                     }
                 }
 
+                init() {
+                }
+
+                @available(*, deprecated, message: "Use init() instead to initialize a mock") init(_ x: String, y: Int, andZ z: Bool) {
+                }
+
                 func foo() {
                     recordCall()
                     return stubOutput()
@@ -735,6 +741,87 @@ final class AddMockMacroExpansionStructTests: AddMockMacroExpansionTestCase {
                         setStub(value: newValue)
                     }
                 }
+            }
+
+            #endif
+            """
+        }
+    }
+
+    func testPublicStruct() {
+        assertMacro {
+            """
+            @AddMock
+            public struct SomeStruct {
+                var x = "Hello World"
+                private var y = 0
+                public var z = true
+
+                init(x: String) {
+                    self.x = x
+                }
+
+                func foo() {}
+                private func bar() {}
+                public func baz() {}
+            }
+            """
+        } expansion: {
+            """
+            public struct SomeStruct {
+                var x = "Hello World"
+                private var y = 0
+                public var z = true
+
+                init(x: String) {
+                    self.x = x
+                }
+
+                func foo() {}
+                private func bar() {}
+                public func baz() {}
+            }
+
+            #if DEBUG
+
+            public struct MockSomeStruct: Mock {
+
+                public let blackBox = BlackBox()
+                public let stubRegistry = StubRegistry()
+
+                var x {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                public var z {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+
+                init() {
+                }
+
+                @available(*, deprecated, message: "Use init() instead to initialize a mock") init(x: String) {
+                }
+
+                func foo() {
+                    recordCall()
+                    return stubOutput()
+                }
+
+                public func baz() {
+                    recordCall()
+                    return stubOutput()
+                }
+
             }
 
             #endif

--- a/Tests/TestDRSTests/Integration/AddMockToPublicTypeTests.swift
+++ b/Tests/TestDRSTests/Integration/AddMockToPublicTypeTests.swift
@@ -1,0 +1,108 @@
+//
+// Created on 3/6/25.
+// Copyright © 2025 Turo Open Source. All rights reserved.
+//
+
+import Foundation
+import TestDRS
+import Testing
+
+// Verifying that the mocks are generated properly by lack of build errors.
+
+@AddMock
+public protocol SomePublicProtocol: Sendable, Identifiable {
+    var id: UUID { get }
+    var x: String { get }
+    var y: Int { get set }
+    static var z: Bool { get }
+
+    func foo()
+    func bar(paramOne: Int)
+    func baz<T>(paramOne: Bool, paramTwo: T) -> T
+    func bam() throws
+
+    static func oof() -> String
+
+    init(x: String, y: Int)
+}
+
+@AddMock
+public struct SomePublicStruct: SomePublicProtocol {
+
+    public let id = UUID()
+
+    private var a = "This should not be mocked"
+
+    public var x: String { "No" }
+    public var y: Int
+    nonisolated(unsafe) public static var z: Bool = true
+
+    public init(x: String, y: Int) {
+        self.y = y
+    }
+
+    public func foo() {
+        fatalError("Unimplemented")
+    }
+
+    public func bar(paramOne: Int) {
+        fatalError("Unimplemented")
+    }
+
+    public func baz<T>(paramOne: Bool, paramTwo: T) -> T {
+        fatalError("Unimplemented")
+    }
+
+    public func bam() throws {
+        fatalError("Unimplemented")
+    }
+
+    public static func oof() -> String {
+        fatalError("Unimplemented")
+    }
+
+}
+
+@AddMock
+public class SomePublicClass: NSObject, SomePublicProtocol, @unchecked Sendable {
+
+    public var id = UUID()
+
+    private let a = "This should not be mocked"
+
+    @objc public var x = "x"
+    public var y = 123
+    public class var z: Bool { true }
+
+    public required init(x: String, y: Int) {
+        self.x = x
+        self.y = y
+        self.x = "This should not be in the mock"
+        self.y = 1_000_000
+    }
+
+    public func foo() {
+        fatalError("Unimplemented")
+    }
+
+    public func bar(paramOne: Int) {
+        fatalError("Unimplemented")
+    }
+
+    public func baz<T>(paramOne: Bool, paramTwo: T) -> T {
+        fatalError("Unimplemented")
+    }
+
+    public func bam() throws {
+        fatalError("Unimplemented")
+    }
+
+    public class func oof() -> String {
+        fatalError("Unimplemented")
+    }
+
+    public final func rab() {
+        fatalError("Unimplemented")
+    }
+
+}

--- a/Tests/TestDRSTests/Integration/MockIntegrationTests.swift
+++ b/Tests/TestDRSTests/Integration/MockIntegrationTests.swift
@@ -105,18 +105,15 @@ struct MockIntegrationTests {
     @Test @MainActor
     func testAddToMockClassProperties() {
         withStaticTestingContext {
-            let mockClass = AddMockToClass(x: "Hello World", y: 89)
+            let mockClass = AddMockToClass()
+
+            mockClass.x = "Hello World"
+            mockClass.y = 89
+            AddMockToClass.z = true
 
             #expect(mockClass.x == "Hello World")
             #expect(mockClass.y == 89)
-
-            mockClass.x = "Goodbye"
-            mockClass.y = 24
-            AddMockToClass.z = false
-
-            #expect(mockClass.x == "Goodbye")
-            #expect(mockClass.y == 24)
-            #expect(AddMockToClass.z == false)
+            #expect(AddMockToClass.z == true)
         }
     }
 
@@ -193,6 +190,8 @@ private protocol SomeProtocol: Sendable, Identifiable {
     func bam() throws
 
     static func oof() -> String
+
+    init(x: String, y: Int)
 }
 
 @AddMock
@@ -206,7 +205,7 @@ private struct SomeStruct: SomeProtocol {
     var y: Int
     nonisolated(unsafe) static var z: Bool = true
 
-    init(y: Int) {
+    init(x: String, y: Int) {
         self.y = y
     }
 
@@ -243,7 +242,7 @@ private class SomeClass: NSObject, SomeProtocol, @unchecked Sendable {
     var y = 123
     class var z: Bool { true }
 
-    init(x: String, y: Int) {
+    required init(x: String, y: Int) {
         self.x = x
         self.y = y
         self.x = "This should not be in the mock"
@@ -276,6 +275,12 @@ private class SomeClass: NSObject, SomeProtocol, @unchecked Sendable {
 
 }
 
+extension MockSomeClass {
+    convenience init() {
+        self.init(x: "", y: 0)
+    }
+}
+
 @Mock
 private struct MockStruct: SomeProtocol {
     var id: UUID
@@ -283,6 +288,13 @@ private struct MockStruct: SomeProtocol {
     var y: Int
 
     static var z: Bool
+
+    init() {}
+
+    init(x: String, y: Int) {
+        self.x = x
+        self.y = y
+    }
 
     func foo()
     func bar(paramOne: Int)
@@ -298,6 +310,13 @@ private class MockClass: SomeProtocol, @unchecked Sendable {
     var y: Int
 
     static var z: Bool
+
+    init() {}
+
+    required init(x: String, y: Int) {
+        self.x = x
+        self.y = y
+    }
 
     func foo()
     func bar(paramOne: Int)


### PR DESCRIPTION
The main update here is to fix an issue that @MrAdamBoyd found where public protocols are not properly mocked using `@AddMock`. 

While I was working on the `@AddMock` expansion code, I made some updates to refactor and clean things up as well as handling initializers better. I decided to make generated mock subclasses not attempt to override initializers at all, since I'm sure that would be brittle and I'd rather nix that before it starts getting any use. 

Mocks generated from protocols and structs now include any inits from the source type. An empty `init()` is always generated for these types and all other generated inits are marked as deprecated. See the updated documentation for `@AddMock` for more information.