### PR TITLE
fix: make mock members public if necessary

### DIFF
--- a/Tests/TestDRSTests/Integration/MockPublicTypeTests.swift
+++ b/Tests/TestDRSTests/Integration/MockPublicTypeTests.swift
@@ -1,0 +1,54 @@
+//
+// Created on 3/6/25.
+// Copyright © 2025 Turo Open Source. All rights reserved.
+//
+
+import Foundation
+import TestDRS
+import Testing
+
+// Verifying that the mocks are generated properly by lack of build errors.
+
+@Mock
+public struct SomePublicMockStruct: SomePublicProtocol {
+    public var id: UUID
+    public var x: String
+    public var y: Int
+
+    public static var z: Bool
+
+    public init() {}
+
+    public init(x: String, y: Int) {
+        self.x = x
+        self.y = y
+    }
+
+    public func foo()
+    public func bar(paramOne: Int)
+    public func baz<T>(paramOne: Bool, paramTwo: T) -> T
+    public func bam() throws
+    public static func oof() -> String
+}
+
+@Mock
+public class SomePublicMockClass: SomePublicProtocol, @unchecked Sendable {
+    public var id: UUID
+    public var x: String
+    public var y: Int
+
+    public static var z: Bool
+
+    public init() {}
+
+    public required init(x: String, y: Int) {
+        self.x = x
+        self.y = y
+    }
+
+    public func foo()
+    public func bar(paramOne: Int)
+    public func baz<T>(paramOne: Bool, paramTwo: T) -> T
+    public func bam() throws
+    public static func oof() -> String
+}


### PR DESCRIPTION
Fixes issue #50 which @MrAdamBoyd found by checking if the mocked type is public and if so making the `blackBox` and `stubRegistry` public.