### PR TITLE
Bump minimum to iOS 16

### DIFF
--- a/ExampleClient.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ExampleClient.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,30 @@
 {
   "pins" : [
     {
-      "identity" : "swift-issue-reporting",
+      "identity" : "swift-custom-dump",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-issue-reporting",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "357ca1e5dd31f613a1d43320870ebc219386a495",
-        "version" : "1.2.2"
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-plugin",
+      "state" : {
+        "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
+        "version" : "1.4.3"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {
@@ -14,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-macro-testing",
       "state" : {
-        "revision" : "851c8b6bde2000d8051dc9aca1efee04dcc37411",
-        "version" : "0.4.1"
+        "revision" : "0b80a098d4805a21c412b65f01ffde7b01aab2fa",
+        "version" : "0.6.0"
       }
     },
     {
@@ -23,26 +41,26 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "8ddd519780452729c6634ad6bd0d2595938e9ea3",
-        "version" : "1.16.1"
+        "revision" : "b2d4cb30735f4fbc3a01963a9c658336dd21e9ba",
+        "version" : "1.18.1"
       }
     },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "0687f71944021d616d34d922343dcef086855920",
         "version" : "600.0.1"
       }
     },
     {
-      "identity" : "swift-testing",
+      "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-testing.git",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "69d59cfc76e5daf498ca61f5af409f594768eef9",
-        "version" : "0.10.0"
+        "revision" : "39de59b2d47f7ef3ca88a039dff3084688fe27f4",
+        "version" : "1.5.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 
 let package = Package(
     name: "TestDRS",
-    platforms: [.macOS(.v13), .iOS(.v15), .tvOS(.v13), .watchOS(.v6), .macCatalyst(.v13)],
+    platforms: [.macOS(.v13), .iOS(.v16), .tvOS(.v13), .watchOS(.v6), .macCatalyst(.v13)],
     products: [
         .library(
             name: "TestDRS",

--- a/Sources/TestDRS/Macros/ConfirmationOfCallMacro.swift
+++ b/Sources/TestDRS/Macros/ConfirmationOfCallMacro.swift
@@ -5,6 +5,8 @@
 
 import Foundation
 
+// swiftformat:disable spaceAroundOperators
+
 /// Awaits confirmation of a function call.
 ///
 /// Similar to using a `Confirmation` in Swift Testing, this macro allows you to await confirmation that a function was called in
@@ -16,7 +18,6 @@ import Foundation
 ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
 ///   - timeLimit: The maximum amount of time to wait for confirmation. If the time limit is reached before the first call can be confirmed, a test failure is reported. Defaults to a duration that is effectively infinite.
 /// - Returns: A `FunctionCallConfirmation` that waits for the first matching call. Further calls can be confirmed by calling methods on this confirmation.
-@available(iOS 16.0, *)
 @freestanding(expression)
 @discardableResult
 public macro confirmationOfCall<Input, Output>(
@@ -26,7 +27,6 @@ public macro confirmationOfCall<Input, Output>(
     timeLimit: Duration = .maxTimeLimit,
     isolation: isolated(any Actor)? = #isolation
 ) -> FunctionCallConfirmation<MatchingFirst, Input, Output> = #externalMacro(module: "TestDRSMacros", type: "ConfirmationOfCallMacro")
-
 
 /// Awaits confirmation of a function call with an expected input.
 ///
@@ -39,7 +39,6 @@ public macro confirmationOfCall<Input, Output>(
 ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
 ///   - timeLimit: The maximum amount of time to wait for confirmation. If the time limit is reached before the first call can be confirmed, a test failure is reported. Defaults to a duration that is effectively infinite.
 /// - Returns: A `FunctionCallConfirmation` that waits for the first matching call. Further calls can be confirmed by calling methods on this confirmation.
-@available(iOS 16.0, *)
 @freestanding(expression)
 @discardableResult
 public macro confirmationOfCall<each Input: Equatable, Output>(

--- a/Sources/TestDRS/Spy/Blackbox/BlackBox.swift
+++ b/Sources/TestDRS/Spy/Blackbox/BlackBox.swift
@@ -103,7 +103,6 @@ public final class BlackBox: @unchecked Sendable {
 
 // MARK: - AsyncStream Support
 
-@available(iOS 16.0, *)
 extension BlackBox {
 
     /// Streams all calls with the given input and output type.

--- a/Sources/TestDRS/Spy/CheckInput.swift
+++ b/Sources/TestDRS/Spy/CheckInput.swift
@@ -39,4 +39,4 @@ private func checkEqualOrThrow<T: Equatable>(_ lhs: T, _ rhs: T) throws {
     if lhs != rhs { throw NotEqualError() }
 }
 
-private struct NotEqualError: Error { }
+private struct NotEqualError: Error {}

--- a/Sources/TestDRS/Spy/FunctionCallConfirmation.swift
+++ b/Sources/TestDRS/Spy/FunctionCallConfirmation.swift
@@ -13,7 +13,6 @@ enum FunctionCallConfirmationError: Error {
 /// Encapsulates the result of a `#confirmationOfCall`.
 ///
 /// A `FunctionCallConfirmation` contains any calls that match the confirmation and provides methods for confirming the number of times the given call was recorded.
-@available(iOS 16.0, *)
 public struct FunctionCallConfirmation<AmountMatching: FunctionCallAmountMatching, Input, Output>: Sendable {
 
     private var _matchingCalls: [FunctionCall<Input, Output>] = []
@@ -50,7 +49,6 @@ public struct FunctionCallConfirmation<AmountMatching: FunctionCallAmountMatchin
 
 }
 
-@available(iOS 16.0, *)
 extension FunctionCallConfirmation where AmountMatching == MatchingFirst {
 
     static func confirmFirstCall(
@@ -102,7 +100,6 @@ extension FunctionCallConfirmation where AmountMatching == MatchingFirst {
 
 // MARK: - Matching Calls
 
-@available(iOS 16.0, *)
 extension FunctionCallConfirmation where AmountMatching: MatchingSingle {
 
     /// The matching call or `nil` if no calls were made that match the expectation.
@@ -120,7 +117,6 @@ extension FunctionCallConfirmation where AmountMatching: MatchingSingle {
 
 }
 
-@available(iOS 16.0, *)
 extension FunctionCallConfirmation where AmountMatching: MatchingMultiple {
 
     /// The matching calls or an empty array  if no calls were confirmed.
@@ -148,7 +144,6 @@ extension FunctionCallConfirmation where AmountMatching: MatchingMultiple {
 
 // MARK: - Confirming amount
 
-@available(iOS 16.0, *)
 extension FunctionCallConfirmation where AmountMatching == MatchingFirst, Input: Sendable {
 
     /// Makes a further confirmation that the specified call occurred exactly once.

--- a/Sources/TestDRS/Spy/Spy+Confirmations.swift
+++ b/Sources/TestDRS/Spy/Spy+Confirmations.swift
@@ -18,7 +18,6 @@ public extension Spy {
     ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
     ///   - timeLimit: The maximum amount of time to wait for confirmation. If the time limit is reached before the first call can be confirmed, a test failure is reported. Defaults to a duration that is effectively infinite.
     /// - Returns: A `FunctionCallConfirmation` that waits for the first matching call. Further calls can be confirmed by calling methods on this confirmation.
-    @available(iOS 16.0, *)
     @discardableResult
     func confirmationOfCall<Input, Output>(
         to function: (Input) async throws -> Output,
@@ -26,7 +25,7 @@ public extension Spy {
         taking inputType: Input.Type? = nil,
         returning outputType: Output.Type? = nil,
         timeLimit: Duration = .maxTimeLimit,
-        isolation: isolated(any Actor)? = #isolation,
+        isolation: isolated (any Actor)? = #isolation,
         fileID: StaticString = #fileID,
         filePath: StaticString = #filePath,
         line: UInt = #line,
@@ -58,7 +57,6 @@ public extension Spy {
     ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
     ///   - timeLimit: The maximum amount of time to wait for confirmation. If the time limit is reached before the first call can be confirmed, a test failure is reported. Defaults to a duration that is effectively infinite.
     /// - Returns: A `FunctionCallConfirmation` that waits for the first matching call. Further calls can be confirmed by calling methods on this confirmation.
-    @available(iOS 16.0, *)
     @discardableResult
     func confirmationOfCall<each Input: Equatable, Output>(
         to function: (repeat each Input) async throws -> Output,
@@ -66,7 +64,7 @@ public extension Spy {
         expectedInput: repeat each Input,
         returning: Output.Type? = nil,
         timeLimit: Duration = .maxTimeLimit,
-        isolation: isolated(any Actor)? = #isolation,
+        isolation: isolated (any Actor)? = #isolation,
         fileID: StaticString = #fileID,
         filePath: StaticString = #filePath,
         line: UInt = #line,

--- a/Sources/TestDRS/Spy/Spy+Expectations.swift
+++ b/Sources/TestDRS/Spy/Spy+Expectations.swift
@@ -217,7 +217,6 @@ public extension Spy {
 
 }
 
-@available(iOS 16.0, *)
 extension Duration {
     /// A duration that is long enough to essentially be considered infinite, but short enough to not cause an error when used to sleep a `Task`.
     public static let maxTimeLimit = Duration.seconds(Int32.max)


### PR DESCRIPTION
Tests were broken if you had iOS selected as the platform, and fixing that required wrapping all the tests that referenced `confirmationOfCall` in an `if #available` since `@available` doesn't work with Swift Testing tests. I actually tried doing that and for some reason the git diff was so bad I couldn't make heads or tails of what was happening. So... I figured I'd just bump the minimum to iOS16 since that is already a couple versions back and about to be 3 versions back this fall.