### PR TITLE
fix: public mock initializer issues

### DIFF
--- a/Sources/TestDRSMacros/Mocking/AddMockMacroExpansion.swift
+++ b/Sources/TestDRSMacros/Mocking/AddMockMacroExpansion.swift
@@ -38,6 +38,10 @@ public struct AddMockMacro: PeerMacro {
             typeBeingMocked != .class
         }
 
+        var needsPublicInit: Bool {
+            isPublic && typeBeingMocked != .class
+        }
+
         var shouldMockStaticMembers: Bool {
             typeBeingMocked != .class
         }
@@ -271,7 +275,7 @@ public struct AddMockMacro: PeerMacro {
             .filter { !$0.isPrivate }
             .map { mockInit(for: $0, config: config) }
 
-        let emptyInitIsNeeded = !mockInits.isEmpty || config.shouldMakeMembersPublic
+        let emptyInitIsNeeded = !mockInits.isEmpty || config.needsPublicInit
         let alreadyHasEmptyInit = mockInits.contains(where: { $0.signature.parameterClause.parameters.isEmpty })
 
         if emptyInitIsNeeded && !alreadyHasEmptyInit {
@@ -279,7 +283,7 @@ public struct AddMockMacro: PeerMacro {
                 signature: FunctionSignatureSyntax(parameterClause: FunctionParameterClauseSyntax {}),
                 body: CodeBlockSyntax {}
             )
-            if config.shouldMakeMembersPublic {
+            if config.needsPublicInit {
                 emptyInit.modifiers.append(.publicModifier)
             }
             mockInits.insert(emptyInit, at: 0)

--- a/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionProtocolTests.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionProtocolTests.swift
@@ -319,10 +319,65 @@ final class AddMockMacroExpansionProtocolTests: AddMockMacroExpansionTestCase {
                     }
                 }
 
-                init() {
+                public init() {
                 }
 
                 @available(*, deprecated, message: "Use init() instead to initialize a mock") public init(x: String) {
+                }
+
+                public func foo() throws -> String {
+                    recordCall(returning: String.self)
+                    return try throwingStubOutput()
+                }
+
+                public func bar(paramOne: Bool) {
+                    recordCall(with: paramOne)
+                    return stubOutput(for: paramOne)
+                }
+
+            }
+
+            #endif
+            """
+        }
+    }
+
+    func testPublicProtocolWithoutInit() {
+        assertMacro {
+            """
+            @AddMock
+            public protocol SomeProtocol {
+                var x: String
+                func foo() throws -> String
+                mutating func bar(paramOne: Bool)
+            }
+            """
+        } expansion: {
+            """
+            public protocol SomeProtocol {
+                var x: String
+                func foo() throws -> String
+                mutating func bar(paramOne: Bool)
+            }
+
+            #if DEBUG
+
+            final
+            public class MockSomeProtocol: SomeProtocol, Mock {
+
+                public let blackBox = BlackBox()
+                public let stubRegistry = StubRegistry()
+
+                public var x: String {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+
+                public init() {
                 }
 
                 public func foo() throws -> String {

--- a/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionStructTests.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionStructTests.swift
@@ -806,7 +806,7 @@ final class AddMockMacroExpansionStructTests: AddMockMacroExpansionTestCase {
                     }
                 }
 
-                init() {
+                public init() {
                 }
 
                 @available(*, deprecated, message: "Use init() instead to initialize a mock") init(x: String) {
@@ -829,5 +829,74 @@ final class AddMockMacroExpansionStructTests: AddMockMacroExpansionTestCase {
         }
     }
 
+    func testPublicStructWithoutInit() {
+        assertMacro {
+            """
+            @AddMock
+            public struct SomeStruct {
+                var x = "Hello World"
+                private var y = 0
+                public var z = true
+
+                func foo() {}
+                private func bar() {}
+                public func baz() {}
+            }
+            """
+        } expansion: {
+            """
+            public struct SomeStruct {
+                var x = "Hello World"
+                private var y = 0
+                public var z = true
+
+                func foo() {}
+                private func bar() {}
+                public func baz() {}
+            }
+
+            #if DEBUG
+
+            public struct MockSomeStruct: Mock {
+
+                public let blackBox = BlackBox()
+                public let stubRegistry = StubRegistry()
+
+                var x {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+                public var z {
+                    get {
+                        stubValue()
+                    }
+                    set {
+                        setStub(value: newValue)
+                    }
+                }
+
+                public init() {
+                }
+
+                func foo() {
+                    recordCall()
+                    return stubOutput()
+                }
+
+                public func baz() {
+                    recordCall()
+                    return stubOutput()
+                }
+
+            }
+
+            #endif
+            """
+        }
+    }
 }
 #endif


### PR DESCRIPTION
This fixes a few public initializer issues that I had missed with the `@AddMock` macro.