### PR TITLE
Add diagnostic for actor-constrained protocols

### DIFF
--- a/Sources/TestDRSMacros/Mocking/AddMockExpansionDiagnostic.swift
+++ b/Sources/TestDRSMacros/Mocking/AddMockExpansionDiagnostic.swift
@@ -9,6 +9,7 @@ enum AddMockExpansionDiagnostic: String, DiagnosticMessage {
 
     case invalidType
     case finalClass
+    case actorConstrained
 
     var message: String {
         switch self {
@@ -16,6 +17,8 @@ enum AddMockExpansionDiagnostic: String, DiagnosticMessage {
             "@AddMock can only be applied to protocols, classes, and structs"
         case .finalClass:
             "@AddMock can't be applied to final classes as they can not be subclassed to produce a mock."
+        case .actorConstrained:
+            "@AddMock can't be applied to actor-constrained protocols. Consider using a more general constraint like Sendable to allow for class-based mocks."
         }
     }
 

--- a/Sources/TestDRSMacros/Mocking/AddMockMacroExpansion.swift
+++ b/Sources/TestDRSMacros/Mocking/AddMockMacroExpansion.swift
@@ -64,6 +64,15 @@ public struct AddMockMacro: PeerMacro {
         let mockDeclaration: DeclSyntax
 
         if let protocolDeclaration = declaration.as(ProtocolDeclSyntax.self) {
+            guard !(protocolDeclaration.inheritanceClause?.containsActor == true) else {
+                context.diagnose(
+                    Diagnostic(
+                        node: Syntax(node),
+                        message: AddMockExpansionDiagnostic.actorConstrained
+                    )
+                )
+                return []
+            }
             mockDeclaration = DeclSyntax(mockClassDeclaration(from: protocolDeclaration))
         } else if let classDeclaration = declaration.as(ClassDeclSyntax.self) {
             mockDeclaration = DeclSyntax(mockSubclassDeclaration(from: classDeclaration, context: context))

--- a/Sources/TestDRSMacros/SyntaxExtensions/InheritanceClauseSyntax+Additions.swift
+++ b/Sources/TestDRSMacros/SyntaxExtensions/InheritanceClauseSyntax+Additions.swift
@@ -11,6 +11,10 @@ extension InheritanceClauseSyntax {
         InheritanceClauseSyntax(inheritedTypes: [])
     }
 
+    var containsActor: Bool {
+        inheritedTypes.contains { $0.type.as(IdentifierTypeSyntax.self)?.name.tokenKind == .identifier("Actor") }
+    }
+
     /// Appends the given types to the inheritance clause syntax.
     ///
     /// - Parameters:

--- a/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionDiagnosticTests.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionDiagnosticTests.swift
@@ -83,6 +83,28 @@ final class AddMockMacroExpansionDiagnosticTests: AddMockMacroExpansionTestCase 
         }
     }
 
+    func testActorConstrainedProtocolProducesDiagnostic() {
+        assertMacro {
+            """
+            @AddMock
+            protocol SomeProtocol: Actor {
+                var foo: String { get set }
+                func bar()
+            }
+            """
+        } diagnostics: {
+            """
+            @AddMock
+            ┬───────
+            ╰─ 🛑 @AddMock can't be applied to actor-constrained protocols. Consider using a more general constraint like Sendable to allow for class-based mocks.
+            protocol SomeProtocol: Actor {
+                var foo: String { get set }
+                func bar()
+            }
+            """
+        }
+    }
+
 }
 
 #endif


### PR DESCRIPTION
After looking into issue #54, TestDRS expectations would currently not play well with a mock actor due to how we access the methods:
<img width="976" alt="Screenshot 2025-04-10 at 1 49 18 PM" src="https://github.com/user-attachments/assets/b148519f-ecb7-4654-a25b-fce1ba3673ea" />

We could potentially get around this by marking members as `nonisolated`, but then what is the point of using an `actor` for the mock? I think in most situations it would suffice to declare your protocol as `Sendable` and leave the details of how it is made thread-safe up to the implementation. The generated mock classes are already `Sendable`, as all properties are computed using the `StubRegistry`.

So in this PR, we simply add a diagnostic to inform the user that we don't support actor-constrained protocols.