### PR TITLE
Debug description improvements

### DIFF
--- a/Sources/TestDRS/Mock.swift
+++ b/Sources/TestDRS/Mock.swift
@@ -42,4 +42,17 @@ import Foundation
 ///     XCTAssertEqual(result, 42)
 /// }
 /// ```
-public protocol Mock: StubProviding, Spy, StaticTestable {}
+public protocol Mock: StubProviding, Spy, StaticTestable, CustomDebugStringConvertible {}
+
+extension Mock where Self: AnyObject {
+    public var debugDescription: String {
+        "Stub Registry:\n\(stubRegistry)Black Box:\n\(blackBox)"
+    }
+}
+
+extension Mock {
+    public var debugDescription: String {
+        // The default memberwise description is sufficient for structs
+        ""
+    }
+}

--- a/Sources/TestDRS/Spy/FunctionCall.swift
+++ b/Sources/TestDRS/Spy/FunctionCall.swift
@@ -46,8 +46,8 @@ extension FunctionCallRepresentation {
         """
         ******* Function Call \(id) *******
         signature: \(signature)
-        input: \(input)
-        outputType: \(outputType)
+        input: \(String(describing: input).asVoidIfEmptyParens())
+        outputType: \(String(describing: outputType).asVoidIfEmptyParens())
         time: \(FunctionCallUtilities.dateFormatter.string(from: time))
         """
     }
@@ -91,4 +91,15 @@ public struct FunctionCall<Input, Output>: FunctionCallRepresentation, @unchecke
     /// A unique identifier for this function call.
     public let id: Int
 
+}
+
+extension String {
+    /// Convert empty parens to "Void" for clarity in debug descriptions.
+    func asVoidIfEmptyParens() -> String {
+        if self == "()" {
+            "Void"
+        } else {
+            self
+        }
+    }
 }

--- a/Sources/TestDRS/Stub/StubRegistry/FunctionStubIdentifier.swift
+++ b/Sources/TestDRS/Stub/StubRegistry/FunctionStubIdentifier.swift
@@ -38,8 +38,8 @@ extension StubRegistry.FunctionStubIdentifier: CustomDebugStringConvertible {
     public var debugDescription: String {
         """
         signature: \(signature)
-        inputType: \(inputType)
-        outputType: \(outputType)
+        inputType: \(inputType.asVoidIfEmptyParens())
+        outputType: \(outputType.asVoidIfEmptyParens())
         """
     }
 }

--- a/Sources/TestDRS/Stub/StubRegistry/Stub.swift
+++ b/Sources/TestDRS/Stub/StubRegistry/Stub.swift
@@ -38,7 +38,7 @@ extension StubRegistry.Stub: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
         case .output(let output):
-            "stubbed output: \(output)"
+            "stubbed output: \(String(describing: output).asVoidIfEmptyParens())"
         case .error(let error):
             "stubbed error: \(error)"
         case .closure:

--- a/Tests/TestDRSTests/Spy/SpyTests.swift
+++ b/Tests/TestDRSTests/Spy/SpyTests.swift
@@ -185,26 +185,26 @@ final class SpyTests: XCTestCase {
 
             ******* Function Call 1 *******
             signature: "foo()"
-            input: ()
-            outputType: ()
+            input: Void
+            outputType: Void
             time: 2018-06-15 0:00:00.000
             \(space)
             ******* Function Call 2 *******
             signature: "bar(paramOne:)"
             input: true
-            outputType: ()
+            outputType: Void
             time: 2018-06-15 0:00:01.000
             \(space)
             ******* Function Call 3 *******
             signature: "baz(paramOne:)"
             input: nil
-            outputType: ()
+            outputType: Void
             time: 2018-06-15 0:00:02.000
             \(space)
             ******* Function Call 4 *******
             signature: "oof(paramOne:paramTwo:)"
             input: (false, 7)
-            outputType: ()
+            outputType: Void
             time: 2018-06-15 0:00:03.000
             \(space)
 

--- a/Tests/TestDRSTests/Stub/StubProvidingTests.swift
+++ b/Tests/TestDRSTests/Stub/StubProvidingTests.swift
@@ -251,7 +251,7 @@ final class StubProvidingTests: XCTestCase {
             \(space)
             ******* Function Stub *******
             signature: "foo()"
-            inputType: ()
+            inputType: Void
             outputType: Int
             stubbed output: 7
             \(space)


### PR DESCRIPTION
- Replaces `()` with `Void` in debug descriptions
- Adds a custom debug description for mock classes so you can simply `po someMock` and see both the stub registry and the black box
  - Avoids adding a custom debug description for structs as they already print out their members, so a custom description would duplicate what is already printed