### PR TITLE
fix: add override keyword to NSObject mock subclass initializers

### DIFF
--- a/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionProtocolTests.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionProtocolTests.swift
@@ -236,6 +236,49 @@ final class AddMockMacroExpansionProtocolTests: AddMockMacroExpansionTestCase {
         }
     }
 
+    func testObjectiveCProtocolWithInitializers() {
+        assertMacro {
+            """
+            @AddMock
+            @objc protocol StartEndTimePickingDelegate {
+                init()
+                init(value: String)
+                func foo()
+            }
+            """
+        } expansion: {
+            """
+            @objc protocol StartEndTimePickingDelegate {
+                init()
+                init(value: String)
+                func foo()
+            }
+
+            #if DEBUG
+
+            @objc final class MockStartEndTimePickingDelegate: NSObject, StartEndTimePickingDelegate, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                override init() {
+                }
+
+                @available(*, deprecated, message: "Use init() instead to initialize a mock") override init(value: String) {
+                }
+
+                func foo() {
+                    recordCall()
+                    return stubOutput()
+                }
+
+            }
+
+            #endif
+            """
+        }
+    }
+
     func testGenericProtocol() {
         assertMacro {
             """


### PR DESCRIPTION
 ## Summary
  Fixes issue where `@AddMock` with `@objc` protocols that declare initializers would generate mock classes inheriting from NSObject without the
  required `override` keyword on initializers, causing Swift compiler errors.

 ## Changes
  - Added `inheritsFromNSObject` property to `MockGenerationConfig` to track NSObject inheritance
  - Added `shouldOverrideInitializers` property to determine when initializers need override keyword
  - Updated `mockInit` function to add override keyword when needed
  - Updated all `MockGenerationConfig` initializations to pass the new parameter
  - Added comprehensive test case `testObjectiveCProtocolWithInitializers()`

  ## Test plan
  - [x] New test case verifies override keywords are correctly added to initializers
  - [x] Existing protocol tests continue to pass
  - [x] Existing class tests continue to pass
  - [x] Functions in @objc protocols correctly do NOT get override keyword

  🤖 Generated with [Claude Code](https://claude.ai/code)