### PR TITLE
Fix dynamic stubs to handle closures assigned to variables

### DIFF
--- a/Sources/TestDRSMacros/Stubbing/StubMacroExpansion.swift
+++ b/Sources/TestDRSMacros/Stubbing/StubMacroExpansion.swift
@@ -122,11 +122,11 @@ public struct SetStubUsingClosureMacro: ExpressionMacro {
 
         if let memberAccess = firstArgument.as(MemberAccessExprSyntax.self), let base = memberAccess.base {
             return """
-            \(base).setDynamicStub(for: \(memberAccess), withSignature: "\(memberAccess.declName)")\(closure)
+            \(base).setDynamicStub(for: \(memberAccess), withSignature: "\(memberAccess.declName)", using: \(closure))
             """
         } else if let expression = firstArgument.as(DeclReferenceExprSyntax.self) {
             return """
-            setDynamicStub(for: \(expression), withSignature: "\(expression)")\(closure)
+            setDynamicStub(for: \(expression), withSignature: "\(expression)", using: \(closure))
             """
         } else {
             context.diagnose(

--- a/Tests/TestDRSMacrosTests/Stubbing/SetStubUsingClosureMacroExpansionTests.swift
+++ b/Tests/TestDRSMacrosTests/Stubbing/SetStubUsingClosureMacroExpansionTests.swift
@@ -28,9 +28,9 @@ final class SetStubUsingClosureMacroExpansionTests: XCTestCase {
             """
         } expansion: {
             """
-            mock.setDynamicStub(for: mock.foo, withSignature: "foo") {
-                "Hello World"
-            }
+            mock.setDynamicStub(for: mock.foo, withSignature: "foo", using: {
+                    "Hello World"
+                })
             """
         }
     }
@@ -42,9 +42,9 @@ final class SetStubUsingClosureMacroExpansionTests: XCTestCase {
             """
         } expansion: {
             """
-            mock.setDynamicStub(for: mock.foo(_:paramTwo:), withSignature: "foo(_:paramTwo:)") {
-                "Hello World"
-            }
+            mock.setDynamicStub(for: mock.foo(_:paramTwo:), withSignature: "foo(_:paramTwo:)", using: {
+                    "Hello World"
+                })
             """
         }
     }
@@ -56,9 +56,9 @@ final class SetStubUsingClosureMacroExpansionTests: XCTestCase {
             """
         } expansion: {
             """
-            setDynamicStub(for: foo, withSignature: "foo") {
-                "Hello World"
-            }
+            setDynamicStub(for: foo, withSignature: "foo", using: {
+                    "Hello World"
+                })
             """
         }
     }
@@ -74,9 +74,23 @@ final class SetStubUsingClosureMacroExpansionTests: XCTestCase {
             """
             let x = "Hello "
             let y = "World"
-            setDynamicStub(for: foo(_:paramTwo:), withSignature: "foo(_:paramTwo:)") {
-                x + y
-            }
+            setDynamicStub(for: foo(_:paramTwo:), withSignature: "foo(_:paramTwo:)", using: {
+                    x + y
+                })
+            """
+        }
+    }
+
+    func testStubbingMethod_WithClosureVariable() {
+        assertMacro {
+            """
+            let block = { "Hello World" }
+            #stub(mock.foo, using: block)
+            """
+        } expansion: {
+            """
+            let block = { "Hello World" }
+            mock.setDynamicStub(for: mock.foo, withSignature: "foo", using: block)
             """
         }
     }


### PR DESCRIPTION
## Summary
- Fixed the `#stub` macro with dynamic closures to properly handle closures assigned to variables
- The macro now uses the `using:` parameter instead of trailing closure syntax
- Added test case to verify the fix works with closure variables

## Problem
Previously, dynamic stubs only worked with trailing closure syntax:
```swift
#stub(mock.foo, using: { "Hello World" })  // ✅ Worked
```

But failed when using variables containing closures:
```swift
let block = { "Hello World" }
#stub(mock.foo, using: block)  // ❌ Failed with syntax error
```

## Solution
Updated the `SetStubUsingClosureMacro` to generate code using the `using:` parameter instead of trailing closure syntax. This allows both literal closures and closure variables to work properly.

## Test plan
- [x] Added test case `testStubbingMethod_WithClosureVariable` to verify the fix
- [x] All existing tests continue to pass
- [x] Full test suite runs successfully

Fixes #63

🤖 Generated with [Claude Code](https://claude.ai/code)