### PR TITLE
fix: remove Sendable constraint from confirmationOfCall exactlyOnce method

### DIFF
--- a/Sources/TestDRS/Spy/FunctionCallConfirmation.swift
+++ b/Sources/TestDRS/Spy/FunctionCallConfirmation.swift
@@ -144,7 +144,7 @@ extension FunctionCallConfirmation where AmountMatching: MatchingMultiple {
 
 // MARK: - Confirming amount
 
-extension FunctionCallConfirmation where AmountMatching == MatchingFirst, Input: Sendable {
+extension FunctionCallConfirmation where AmountMatching == MatchingFirst {
 
     /// Makes a further confirmation that the specified call occurred exactly once.
     ///

--- a/Tests/TestDRSTests/Integration/NonSendableInputTests.swift
+++ b/Tests/TestDRSTests/Integration/NonSendableInputTests.swift
@@ -1,0 +1,33 @@
+//
+// Created on 7/1/25.
+// Copyright © 2025 Turo Open Source. All rights reserved.
+//
+
+import Foundation
+import TestDRS
+import Testing
+
+struct NonSendableInputTests {
+
+    @Test
+    func confirmationOfCall_WithNonSendableInput_Compiles() async {
+        let mockObject = MockObject()
+        mockObject.processTimer(Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false, block: { _ in }))
+
+        // This test verifies that confirmationOfCall works with non-Sendable input types like Timer
+        // The focus is on compilation, not runtime behavior
+        await #confirmationOfCall(to: mockObject.processTimer).exactlyOnce()
+    }
+
+}
+
+// MARK: - Test Types
+
+/// A mock object for testing non-Sendable input handling
+@Mock
+private struct MockObject {
+
+    /// A method that takes a Timer (non-Sendable) parameter
+    func processTimer(_ timer: Timer)
+
+}

--- a/Tests/TestDRSTests/Spy/ConfirmationOfCallMacroTests.swift
+++ b/Tests/TestDRSTests/Spy/ConfirmationOfCallMacroTests.swift
@@ -109,7 +109,7 @@ struct ConfirmationOfCallMacroTests: Sendable {
     func confirmationOfCall_WithSingleCall_Succeeds() async {
         spy.foo()
 
-        let call = await #confirmationOfCall(to: spy.foo)
+        let call = await #confirmationOfCall(to: spy.foo).matchingCall
 
         #expect(call != nil)
     }


### PR DESCRIPTION
## Summary
- Remove `Input: Sendable` constraint from `FunctionCallConfirmation.exactlyOnce()` method
- Add test case `NonSendableInputTests` to verify non-Sendable input types like `Timer` work with `#confirmationOfCall`
- Fix compiler warning in existing test

## Test plan
- [x] New test `confirmationOfCall_WithNonSendableInput_Compiles()` verifies compilation with `Timer` input
- [x] All existing tests continue to pass
- [x] Build succeeds without Sendable conformance errors

🤖 Generated with [Claude Code](https://claude.ai/code)