### PR TITLE
fix: handle whitespace correctly in stub macro expansion

### DIFF
--- a/Sources/TestDRSMacros/Stubbing/StubMacroExpansion.swift
+++ b/Sources/TestDRSMacros/Stubbing/StubMacroExpansion.swift
@@ -34,9 +34,9 @@ public struct SetStubReturningOutputMacro: ExpressionMacro {
             argument.label?.text == "taking"
         }?.expression
 
-        if let memberAccess = firstArgument.as(MemberAccessExprSyntax.self), let base = memberAccess.base {
+        if let memberAccess = firstArgument.as(MemberAccessExprSyntax.self)?.trimmed, let base = memberAccess.base {
             return """
-            \(base).setStub(for: \(memberAccess), withSignature: "\(memberAccess.declName)", taking: \(inputType == nil ? "nil" : "\(inputType)"), returning: \(output))
+            \(base).setStub(for: \(memberAccess), withSignature: \(literal: memberAccess.declName.description), taking: \(inputType == nil ? "nil" : "\(inputType)"), returning: \(output))
             """
         } else if let expression = firstArgument.as(DeclReferenceExprSyntax.self)?.trimmed {
             return """
@@ -79,9 +79,9 @@ public struct SetStubThrowingErrorMacro: ExpressionMacro {
             argument.label?.text == "taking"
         }?.expression
 
-        if let memberAccess = firstArgument.as(MemberAccessExprSyntax.self), let base = memberAccess.base {
+        if let memberAccess = firstArgument.as(MemberAccessExprSyntax.self)?.trimmed, let base = memberAccess.base {
             return """
-            \(base).setStub(for: \(memberAccess), withSignature: "\(memberAccess.declName)", taking: \(inputType == nil ? "nil" : "\(inputType)"), throwing: \(error))
+            \(base).setStub(for: \(memberAccess), withSignature: \(literal: memberAccess.declName.description), taking: \(inputType == nil ? "nil" : "\(inputType)"), throwing: \(error))
             """
         } else if let expression = firstArgument.as(DeclReferenceExprSyntax.self)?.trimmed {
             return """
@@ -120,9 +120,9 @@ public struct SetStubUsingClosureMacro: ExpressionMacro {
             return ""
         }
 
-        if let memberAccess = firstArgument.as(MemberAccessExprSyntax.self), let base = memberAccess.base {
+        if let memberAccess = firstArgument.as(MemberAccessExprSyntax.self)?.trimmed, let base = memberAccess.base {
             return """
-            \(base).setDynamicStub(for: \(memberAccess), withSignature: "\(memberAccess.declName)", using: \(closure))
+            \(base).setDynamicStub(for: \(memberAccess), withSignature: \(literal: memberAccess.declName.description), using: \(closure))
             """
         } else if let expression = firstArgument.as(DeclReferenceExprSyntax.self)?.trimmed {
             return """

--- a/Sources/TestDRSMacros/Stubbing/StubMacroExpansion.swift
+++ b/Sources/TestDRSMacros/Stubbing/StubMacroExpansion.swift
@@ -38,9 +38,9 @@ public struct SetStubReturningOutputMacro: ExpressionMacro {
             return """
             \(base).setStub(for: \(memberAccess), withSignature: "\(memberAccess.declName)", taking: \(inputType == nil ? "nil" : "\(inputType)"), returning: \(output))
             """
-        } else if let expression = firstArgument.as(DeclReferenceExprSyntax.self) {
+        } else if let expression = firstArgument.as(DeclReferenceExprSyntax.self)?.trimmed {
             return """
-            setStub(for: \(expression), withSignature: "\(expression)", taking: \(inputType == nil ? "nil" : "\(inputType)"), returning: \(output))
+            setStub(for: \(expression), withSignature: \(literal: expression.description), taking: \(inputType == nil ? "nil" : "\(inputType)"), returning: \(output))
             """
         } else {
             context.diagnose(
@@ -83,9 +83,9 @@ public struct SetStubThrowingErrorMacro: ExpressionMacro {
             return """
             \(base).setStub(for: \(memberAccess), withSignature: "\(memberAccess.declName)", taking: \(inputType == nil ? "nil" : "\(inputType)"), throwing: \(error))
             """
-        } else if let expression = firstArgument.as(DeclReferenceExprSyntax.self) {
+        } else if let expression = firstArgument.as(DeclReferenceExprSyntax.self)?.trimmed {
             return """
-            setStub(for: \(expression), withSignature: "\(expression)", taking: \(inputType == nil ? "nil" : "\(inputType)"), throwing: \(error))
+            setStub(for: \(expression), withSignature: \(literal: expression.description), taking: \(inputType == nil ? "nil" : "\(inputType)"), throwing: \(error))
             """
         } else {
             context.diagnose(
@@ -124,9 +124,9 @@ public struct SetStubUsingClosureMacro: ExpressionMacro {
             return """
             \(base).setDynamicStub(for: \(memberAccess), withSignature: "\(memberAccess.declName)", using: \(closure))
             """
-        } else if let expression = firstArgument.as(DeclReferenceExprSyntax.self) {
+        } else if let expression = firstArgument.as(DeclReferenceExprSyntax.self)?.trimmed {
             return """
-            setDynamicStub(for: \(expression), withSignature: "\(expression)", using: \(closure))
+            setDynamicStub(for: \(expression), withSignature: \(literal: expression.description), using: \(closure))
             """
         } else {
             context.diagnose(

--- a/Tests/TestDRSMacrosTests/Stubbing/SetStubReturningOutputMacroExpansionTests.swift
+++ b/Tests/TestDRSMacrosTests/Stubbing/SetStubReturningOutputMacroExpansionTests.swift
@@ -77,6 +77,52 @@ final class SetStubReturningOutputMacroTests: XCTestCase {
         }
     }
 
+    func testStubbingMethod_WithMultilineFormatting() {
+        assertMacro {
+            """
+            #stub(
+                foo,
+                returning: "Hello World"
+            )
+            """
+        } expansion: {
+            """
+            setStub(for: foo, withSignature: "foo", taking: nil, returning: "Hello World")
+            """
+        }
+    }
+
+    func testStubbingMethod_WithMultilineFormatting_WithArguments() {
+        assertMacro {
+            """
+            #stub(
+                foo(_:paramTwo:),
+                taking: Int.self,
+                returning: "Hello World"
+            )
+            """
+        } expansion: {
+            """
+            setStub(for: foo(_:paramTwo:), withSignature: "foo(_:paramTwo:)", taking: Int.self, returning: "Hello World")
+            """
+        }
+    }
+
+    func testStubbingMethod_WithMultilineFormatting_WithMemberAccess() {
+        assertMacro {
+            """
+            #stub(
+                mock.foo,
+                returning: "Hello World"
+            )
+            """
+        } expansion: {
+            """
+            mock.setStub(for: mock.foo, withSignature: "foo", taking: nil, returning: "Hello World")
+            """
+        }
+    }
+
 }
 
 #endif

--- a/Tests/TestDRSMacrosTests/Stubbing/SetStubThrowingErrorMacroExpansionTests.swift
+++ b/Tests/TestDRSMacrosTests/Stubbing/SetStubThrowingErrorMacroExpansionTests.swift
@@ -77,6 +77,37 @@ final class SetStubThrowingErrorMacroExpansionTests: XCTestCase {
         }
     }
 
+    func testStubbingMethod_WithMultilineFormatting() {
+        assertMacro {
+            """
+            #stub(
+                foo,
+                throwing: MyError.someError
+            )
+            """
+        } expansion: {
+            """
+            setStub(for: foo, withSignature: "foo", taking: nil, throwing: MyError.someError)
+            """
+        }
+    }
+
+    func testStubbingMethod_WithMultilineFormatting_WithArguments() {
+        assertMacro {
+            """
+            #stub(
+                foo(_:paramTwo:),
+                taking: Int.self,
+                throwing: MyError.someError
+            )
+            """
+        } expansion: {
+            """
+            setStub(for: foo(_:paramTwo:), withSignature: "foo(_:paramTwo:)", taking: Int.self, throwing: MyError.someError)
+            """
+        }
+    }
+
 }
 
 #endif

--- a/Tests/TestDRSMacrosTests/Stubbing/SetStubUsingClosureMacroExpansionTests.swift
+++ b/Tests/TestDRSMacrosTests/Stubbing/SetStubUsingClosureMacroExpansionTests.swift
@@ -95,6 +95,40 @@ final class SetStubUsingClosureMacroExpansionTests: XCTestCase {
         }
     }
 
+    func testStubbingMethod_WithMultilineFormatting() {
+        assertMacro {
+            """
+            #stub(
+                foo,
+                using: { "Hello World" }
+            )
+            """
+        } expansion: {
+            """
+            setDynamicStub(for: foo, withSignature: "foo", using: {
+                    "Hello World"
+                })
+            """
+        }
+    }
+
+    func testStubbingMethod_WithMultilineFormatting_WithArguments() {
+        assertMacro {
+            """
+            #stub(
+                foo(_:paramTwo:),
+                using: { "Hello World" }
+            )
+            """
+        } expansion: {
+            """
+            setDynamicStub(for: foo(_:paramTwo:), withSignature: "foo(_:paramTwo:)", using: {
+                    "Hello World"
+                })
+            """
+        }
+    }
+
 }
 
 #endif

--- a/Tests/TestDRSTests/Stub/MultiLineStub.swift
+++ b/Tests/TestDRSTests/Stub/MultiLineStub.swift
@@ -1,0 +1,20 @@
+//
+// Created on 7/1/25.
+// Copyright © 2025 Turo Open Source. All rights reserved.
+//
+
+import Foundation
+import TestDRS
+
+@Mock
+private struct MultiLineStub {
+    func foo() -> String
+
+    init() {
+        // Testing by virtue of this stub compiling
+        #stub(
+            foo,
+            returning: "bar"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Fix unterminated string literal errors when stub macros are called with multiline formatting
- Properly handle whitespace and newlines in macro expansion by using SwiftSyntax's `.trimmed` property
- Use `literal:` parameter for string interpolation to generate clean signature strings

## Test plan
- [x] Build passes without unterminated string literal errors
- [x] Added test case for multiline stub formatting
- [x] Existing stub functionality remains unchanged

Fixes compilation errors like:
```
macro expansion #stub:2:33: error: unterminated string literal
setStub(for:
        foo, withSignature: "
        foo", taking: nil, returning: Void())
```

Now generates clean single-line code:
```
setStub(for: foo, withSignature: "foo", taking: nil, returning: Void())
```

🤖 Generated with [Claude Code](https://claude.ai/code)