### PR TITLE
feat: change default confirmationOfCall timeout from infinite to 5 seconds

### DIFF
--- a/Sources/TestDRS/Macros/ConfirmationOfCallMacro.swift
+++ b/Sources/TestDRS/Macros/ConfirmationOfCallMacro.swift
@@ -16,7 +16,7 @@ import Foundation
 ///   - function: A reference to the function to expect was called.
 ///   - inputType: An optional phantom parameter used to derive the input type of the `function` passed in.
 ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
-///   - timeLimit: The maximum amount of time to wait for confirmation. If the time limit is reached before the first call can be confirmed, a test failure is reported. Defaults to a duration that is effectively infinite.
+///   - timeLimit: The maximum amount of time to wait for confirmation. If the time limit is reached before the first call can be confirmed, a test failure is reported. Defaults to 5 seconds.
 /// - Returns: A `FunctionCallConfirmation` that waits for the first matching call. Further calls can be confirmed by calling methods on this confirmation.
 @freestanding(expression)
 @discardableResult
@@ -24,7 +24,7 @@ public macro confirmationOfCall<Input, Output>(
     to function: (Input) async throws -> Output,
     taking inputType: Input.Type? = nil,
     returning outputType: Output.Type? = nil,
-    timeLimit: Duration = .maxTimeLimit,
+    timeLimit: Duration = .seconds(5),
     isolation: isolated(any Actor)? = #isolation
 ) -> FunctionCallConfirmation<MatchingFirst, Input, Output> = #externalMacro(module: "TestDRSMacros", type: "ConfirmationOfCallMacro")
 
@@ -37,7 +37,7 @@ public macro confirmationOfCall<Input, Output>(
 ///   - function: A reference to the function to expect was called.
 ///   - expectedInput: The expected input parameter(s) for the function.
 ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
-///   - timeLimit: The maximum amount of time to wait for confirmation. If the time limit is reached before the first call can be confirmed, a test failure is reported. Defaults to a duration that is effectively infinite.
+///   - timeLimit: The maximum amount of time to wait for confirmation. If the time limit is reached before the first call can be confirmed, a test failure is reported. Defaults to 5 seconds.
 /// - Returns: A `FunctionCallConfirmation` that waits for the first matching call. Further calls can be confirmed by calling methods on this confirmation.
 @freestanding(expression)
 @discardableResult
@@ -45,6 +45,6 @@ public macro confirmationOfCall<each Input: Equatable, Output>(
     to function: (repeat each Input) async throws -> Output,
     with expectedInput: repeat each Input,
     returning outputType: Output.Type? = nil,
-    timeLimit: Duration = .maxTimeLimit,
+    timeLimit: Duration = .seconds(5),
     isolation: isolated(any Actor)? = #isolation
 ) -> FunctionCallConfirmation<MatchingFirst, (repeat each Input), Output> = #externalMacro(module: "TestDRSMacros", type: "ConfirmationOfCallMacro")

--- a/Sources/TestDRS/Spy/Spy+Confirmations.swift
+++ b/Sources/TestDRS/Spy/Spy+Confirmations.swift
@@ -16,7 +16,7 @@ public extension Spy {
     ///   - function: A reference to the function to expect was called.
     ///   - inputType: An optional phantom parameter used to derive the input type of the `function` passed in.
     ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
-    ///   - timeLimit: The maximum amount of time to wait for confirmation. If the time limit is reached before the first call can be confirmed, a test failure is reported. Defaults to a duration that is effectively infinite.
+    ///   - timeLimit: The maximum amount of time to wait for confirmation. If the time limit is reached before the first call can be confirmed, a test failure is reported. Defaults to 5 seconds.
     /// - Returns: A `FunctionCallConfirmation` that waits for the first matching call. Further calls can be confirmed by calling methods on this confirmation.
     @discardableResult
     func confirmationOfCall<Input, Output>(
@@ -24,7 +24,7 @@ public extension Spy {
         withSignature signature: FunctionSignature,
         taking inputType: Input.Type? = nil,
         returning outputType: Output.Type? = nil,
-        timeLimit: Duration = .maxTimeLimit,
+        timeLimit: Duration = .seconds(5),
         isolation: isolated (any Actor)? = #isolation,
         fileID: StaticString = #fileID,
         filePath: StaticString = #filePath,
@@ -55,7 +55,7 @@ public extension Spy {
     ///   - function: A reference to the function to expect was called.
     ///   - expectedInput: The expected input parameter(s) for the function.
     ///   - outputType: An optional phantom parameter used to derive the output type of the `function` passed in.
-    ///   - timeLimit: The maximum amount of time to wait for confirmation. If the time limit is reached before the first call can be confirmed, a test failure is reported. Defaults to a duration that is effectively infinite.
+    ///   - timeLimit: The maximum amount of time to wait for confirmation. If the time limit is reached before the first call can be confirmed, a test failure is reported. Defaults to 5 seconds.
     /// - Returns: A `FunctionCallConfirmation` that waits for the first matching call. Further calls can be confirmed by calling methods on this confirmation.
     @discardableResult
     func confirmationOfCall<each Input: Equatable, Output>(
@@ -63,7 +63,7 @@ public extension Spy {
         withSignature signature: FunctionSignature,
         expectedInput: repeat each Input,
         returning: Output.Type? = nil,
-        timeLimit: Duration = .maxTimeLimit,
+        timeLimit: Duration = .seconds(5),
         isolation: isolated (any Actor)? = #isolation,
         fileID: StaticString = #fileID,
         filePath: StaticString = #filePath,

--- a/Sources/TestDRS/Spy/Spy+Expectations.swift
+++ b/Sources/TestDRS/Spy/Spy+Expectations.swift
@@ -216,8 +216,3 @@ public extension Spy {
     }
 
 }
-
-extension Duration {
-    /// A duration that is long enough to essentially be considered infinite, but short enough to not cause an error when used to sleep a `Task`.
-    public static let maxTimeLimit = Duration.seconds(Int32.max)
-}


### PR DESCRIPTION
I thought about making this configurable, but I'm just going to roll with making 5 seconds the default, since that should be longer than needed 99% of the time, and it isn't too long to wait to see a failure. You can always pass in a larger value if tests are flaking on CI.

## Summary
- Updated default timeout for `confirmationOfCall` from infinite to 5 seconds
- Updated documentation in both `Spy+Confirmations.swift` and `ConfirmationOfCallMacro.swift`
- Removed unused `maxTimeLimit` constant from `Duration` extension

## Test plan
- [x] Verify existing tests still pass with the new 5-second default
- [x] Confirm documentation accurately reflects the new default timeout
- [x] Check that no references to `maxTimeLimit` remain in the codebase

🤖 Generated with [Claude Code](https://claude.ai/code)