### PR TITLE
Fix NSObject mock initializer override keyword

### DIFF
--- a/Sources/TestDRSMacros/Mocking/AddMockMacroExpansion.swift
+++ b/Sources/TestDRSMacros/Mocking/AddMockMacroExpansion.swift
@@ -21,6 +21,7 @@ public struct AddMockMacro: PeerMacro {
     private struct MockGenerationConfig {
         let typeBeingMocked: TypeBeingMocked
         let isPublic: Bool
+        let inheritsFromNSObject: Bool
 
         var shouldMakeMembersPublic: Bool {
             isPublic && typeBeingMocked == .protocol
@@ -44,6 +45,10 @@ public struct AddMockMacro: PeerMacro {
 
         var shouldMockStaticMembers: Bool {
             typeBeingMocked != .class
+        }
+
+        var shouldOverrideInitializers: Bool {
+            inheritsFromNSObject
         }
 
         func shouldMockMember(member: WithModifiersSyntax) -> Bool {
@@ -114,7 +119,7 @@ public struct AddMockMacro: PeerMacro {
                     .compactMap { $0 }
             ),
             members: protocolDeclaration.memberBlock.members,
-            config: .init(typeBeingMocked: .protocol, isPublic: protocolDeclaration.isPublic)
+            config: .init(typeBeingMocked: .protocol, isPublic: protocolDeclaration.isPublic, inheritsFromNSObject: nsObject != nil)
         )
 
         if let associatedTypeClause = protocolDeclaration.primaryAssociatedTypeClause {
@@ -166,7 +171,7 @@ public struct AddMockMacro: PeerMacro {
             named: className,
             inheritanceClause: inheritanceClause,
             members: classDeclaration.memberBlock.members,
-            config: .init(typeBeingMocked: .class, isPublic: classDeclaration.isPublic)
+            config: .init(typeBeingMocked: .class, isPublic: classDeclaration.isPublic, inheritsFromNSObject: false)
         )
 
         subclassDeclaration.modifiers += classDeclaration.modifiers
@@ -181,7 +186,7 @@ public struct AddMockMacro: PeerMacro {
 
         mockStructDeclaration.memberBlock.members = mockMembers(
             from: structDeclaration.memberBlock.members,
-            config: .init(typeBeingMocked: .struct, isPublic: structDeclaration.isPublic)
+            config: .init(typeBeingMocked: .struct, isPublic: structDeclaration.isPublic, inheritsFromNSObject: false)
         )
         mockStructDeclaration.name = mockTypeName(from: structDeclaration.name.trimmedDescription)
         mockStructDeclaration.inheritanceClause = (structDeclaration.inheritanceClause ?? .emptyClause).appending([mockProtocolName])
@@ -295,6 +300,9 @@ public struct AddMockMacro: PeerMacro {
             if config.needsPublicInit {
                 emptyInit.modifiers.append(.publicModifier)
             }
+            if config.shouldOverrideInitializers {
+                emptyInit.modifiers.append(.overrideModifier)
+            }
             mockInits.insert(emptyInit, at: 0)
         }
 
@@ -352,6 +360,10 @@ public struct AddMockMacro: PeerMacro {
 
         if config.shouldMakeMembersPublic && !mockInit.hasExplicitAccessControl {
             mockInit.modifiers += [.publicModifier]
+        }
+
+        if config.shouldOverrideInitializers && !mockInit.isOverride {
+            mockInit.modifiers += [.overrideModifier]
         }
 
         if !mockInit.signature.parameterClause.parameters.isEmpty {

--- a/Sources/TestDRSMacros/Mocking/AddMockMacroExpansion.swift
+++ b/Sources/TestDRSMacros/Mocking/AddMockMacroExpansion.swift
@@ -47,8 +47,10 @@ public struct AddMockMacro: PeerMacro {
             typeBeingMocked != .class
         }
 
-        var shouldOverrideInitializers: Bool {
-            inheritsFromNSObject
+        func shouldOverrideInitializer(_ initializer: InitializerDeclSyntax) -> Bool {
+            guard inheritsFromNSObject else { return false }
+            // Only override init() - NSObject doesn't have other designated initializers
+            return initializer.signature.parameterClause.parameters.isEmpty
         }
 
         func shouldMockMember(member: WithModifiersSyntax) -> Bool {
@@ -300,7 +302,7 @@ public struct AddMockMacro: PeerMacro {
             if config.needsPublicInit {
                 emptyInit.modifiers.append(.publicModifier)
             }
-            if config.shouldOverrideInitializers {
+            if config.shouldOverrideInitializer(emptyInit) {
                 emptyInit.modifiers.append(.overrideModifier)
             }
             mockInits.insert(emptyInit, at: 0)
@@ -362,7 +364,7 @@ public struct AddMockMacro: PeerMacro {
             mockInit.modifiers += [.publicModifier]
         }
 
-        if config.shouldOverrideInitializers && !mockInit.isOverride {
+        if config.shouldOverrideInitializer(initializer) && !mockInit.isOverride {
             mockInit.modifiers += [.overrideModifier]
         }
 

--- a/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionProtocolTests.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionProtocolTests.swift
@@ -300,7 +300,7 @@ final class AddMockMacroExpansionProtocolTests: AddMockMacroExpansionTestCase {
                 override init() {
                 }
 
-                @available(*, deprecated, message: "Use init() instead to initialize a mock") override init(value: String) {
+                @available(*, deprecated, message: "Use init() instead to initialize a mock") init(value: String) {
                 }
 
                 func foo() {

--- a/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionProtocolTests.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionProtocolTests.swift
@@ -236,6 +236,85 @@ final class AddMockMacroExpansionProtocolTests: AddMockMacroExpansionTestCase {
         }
     }
 
+    func testObjectiveCProtocolWithInitializer() {
+        assertMacro {
+            """
+            @AddMock
+            @objc protocol SomeProtocol {
+                init()
+                func foo()
+            }
+            """
+        } expansion: {
+            """
+            @objc protocol SomeProtocol {
+                init()
+                func foo()
+            }
+
+            #if DEBUG
+
+            @objc final class MockSomeProtocol: NSObject, SomeProtocol, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                override init() {
+                }
+
+                func foo() {
+                    recordCall()
+                    return stubOutput()
+                }
+
+            }
+
+            #endif
+            """
+        }
+    }
+
+    func testObjectiveCProtocolWithParameterizedInitializer() {
+        assertMacro {
+            """
+            @AddMock
+            @objc protocol SomeProtocol {
+                init(value: String)
+                func foo()
+            }
+            """
+        } expansion: {
+            """
+            @objc protocol SomeProtocol {
+                init(value: String)
+                func foo()
+            }
+
+            #if DEBUG
+
+            @objc final class MockSomeProtocol: NSObject, SomeProtocol, Mock {
+
+                let blackBox = BlackBox()
+                let stubRegistry = StubRegistry()
+
+                override init() {
+                }
+
+                @available(*, deprecated, message: "Use init() instead to initialize a mock") override init(value: String) {
+                }
+
+                func foo() {
+                    recordCall()
+                    return stubOutput()
+                }
+
+            }
+
+            #endif
+            """
+        }
+    }
+
     func testGenericProtocol() {
         assertMacro {
             """

--- a/Tests/TestDRSTests/Integration/ObjectiveCProtocolTests.swift
+++ b/Tests/TestDRSTests/Integration/ObjectiveCProtocolTests.swift
@@ -1,0 +1,16 @@
+//
+// Created on 8/12/25.
+// Copyright © 2025 Turo Open Source. All rights reserved.
+//
+
+import Foundation
+import TestDRS
+
+// Verifying that @objc protocol mocks compile with proper override keywords by lack of build errors.
+
+@AddMock
+@objc public protocol SomeObjectiveCProtocol {
+    init()
+    init(value: String)
+    func performAction()
+}


### PR DESCRIPTION
## Summary
- Fixes #59: NSObject mock subclass initializers need override keyword
- Adds `inheritsFromNSObject` property to `MockGenerationConfig`
- Ensures @objc protocol mocks generate `override init()` when inheriting from NSObject

## Test plan
- [x] Added comprehensive test coverage for @objc protocols with initializers
- [x] Verified non-@objc protocols continue working without regression
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)