### PR TITLE
feat: add guidance for use of nonExclusive mode

### DIFF
--- a/Sources/TestDRS/Spy/Blackbox/BlackBox+Expectations.swift
+++ b/Sources/TestDRS/Spy/Blackbox/BlackBox+Expectations.swift
@@ -35,7 +35,7 @@ extension BlackBox {
                     .filter { !expectedCallIds.contains($0.id) }
                     .map { $0.debugDescription }
                     .joined(separator: "\n")
-                let messaage = "\(signature) was called with input type \(Input.self) and output type \(Output.self), but was also called with other input and/or output types:\n\n\(unexpectedCalls)"
+                let messaage = "\(signature) was called with input type \(Input.self) and output type \(Output.self), but was also called with other input and/or output types:\n\n\(unexpectedCalls)\n\nTo ignore non-matching calls, use ExpectedCallMode.nonExclusive."
                 reportFailure(messaage, location: location)
             }
         }
@@ -75,7 +75,7 @@ extension BlackBox {
                     .filter { !expectedCallIDs.contains($0.id) }
                     .map { "+\($0.input)" }
                     .joined(separator: "\n")
-                let message = "\(signature) was called with the expected input, but was also called with other input:\n\n\(unexpectedInputs)"
+                let message = "\(signature) was called with the expected input, but was also called with other input:\n\n\(unexpectedInputs)\n\nTo ignore non-matching calls, use ExpectedCallMode.nonExclusive."
                 reportFailure(message, location: location)
             }
         }

--- a/Tests/TestDRSTests/Spy/Spy+ExpectationsTests.swift
+++ b/Tests/TestDRSTests/Spy/Spy+ExpectationsTests.swift
@@ -6,7 +6,7 @@
 @testable import TestDRS
 import XCTest
 
-final class SpyExpectationsTests {
+final class SpyExpectationsTests: XCTestCase {
 
     private let file = #fileID.components(separatedBy: "/").last!
     private var line = 0
@@ -214,6 +214,21 @@ final class SpyExpectationsTests {
                 issue.description == """
                 Assertion Failure at \(self.file):\(self.line): failed - 2 calls to "zab(paramOne:)" with input type Int and output type Int were recorded
                 """
+            }
+        )
+    }
+
+    func testExpectWasCalled_ShowsNonExclusiveHint() {
+        spy.zab(paramOne: true)
+        spy.zab(paramOne: "Hello")
+        spy.zab(paramOne: 42)
+
+        _ = XCTExpectFailure(
+            failingBlock: {
+                spy.expectWasCalled(spy.zab(paramOne:), withSignature: "zab(paramOne:)", expectedInput: true, mode: .exclusive)
+            },
+            issueMatcher: { issue in
+                issue.description.contains("To ignore non-matching calls, use ExpectedCallMode.nonExclusive.")
             }
         )
     }


### PR DESCRIPTION
I realized when I encountered this message that it could do with being a bit more user-friendly and suggest using the `nonExclusive` mode if the non-matching calls should be ignored.