### PR TITLE
feat: make callsMatching public

### DIFF
--- a/Sources/TestDRS/Spy/Blackbox/BlackBox.swift
+++ b/Sources/TestDRS/Spy/Blackbox/BlackBox.swift
@@ -51,7 +51,7 @@ public final class BlackBox: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - signature: The signature to match.
-    func callsMatching<Input>(
+    public func callsMatching<Input>(
         signature: FunctionSignature,
         taking inputType: Input.Type = Void.self
     ) -> [any FunctionCallRepresentation] {


### PR DESCRIPTION
This isn't 100% ideal, but we need this in order to convert one of our existing mocks to TestDRS. Not adding any documentation or encouraging using this generally.