### PR TITLE
refactor: rename MockLogger to TestDRSMockLogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,14 +282,14 @@ class Logger {
 func testLogging() {
     withStaticTestingContext {
         // Configure mock behavior
-        #stub(MockLogger.isEnabled, returning: true)
-        systemUnderTest.logger = MockLogger.self
+        #stub(TestDRSMockLogger.isEnabled, returning: true)
+        systemUnderTest.logger = TestDRSMockLogger.self
 
         // Test code that uses Logger.log(...)
         systemUnderTest.performAction()
 
         // Verify static method calls
-        #expectWasCalled(MockLogger.log, with: "Action completed", .info)
+        #expectWasCalled(TestDRSMockLogger.log, with: "Action completed", .info)
     }
 }
 ```

--- a/Sources/TestDRS/MockLogging.swift
+++ b/Sources/TestDRS/MockLogging.swift
@@ -14,7 +14,7 @@ import Foundation
 /// - Returns: The result of the operation.
 @discardableResult
 public func withMockLogging<R>(identifier: String = "🏎️", testName: String = #function, operation: () throws -> R) rethrows -> R {
-    try MockLogger.$current.withValue(MockLogger(identifier: identifier, testName: testName)) {
+    try TestDRSMockLogger.$current.withValue(TestDRSMockLogger(identifier: identifier, testName: testName)) {
         try operation()
     }
 }
@@ -28,14 +28,14 @@ public func withMockLogging<R>(identifier: String = "🏎️", testName: String 
 /// - Returns: The result of the operation.
 @discardableResult
 public func withMockLogging<R>(identifier: String = "🏎️", testName: String = #function, operation: () async throws -> R) async rethrows -> R {
-    try await MockLogger.$current.withValue(MockLogger(identifier: identifier, testName: testName)) {
+    try await TestDRSMockLogger.$current.withValue(TestDRSMockLogger(identifier: identifier, testName: testName)) {
         try await operation()
     }
 }
 
 func withMockLogging<R>(identifier: String = "🏎️", testName: String = #function, print: (@Sendable (String) -> Void)? = nil, operation: () throws -> R) rethrows -> R {
-    try MockLogger.$current.withValue(
-        MockLogger(
+    try TestDRSMockLogger.$current.withValue(
+        TestDRSMockLogger(
             identifier: identifier,
             testName: testName,
             print: print
@@ -46,7 +46,7 @@ func withMockLogging<R>(identifier: String = "🏎️", testName: String = #func
 }
 
 /// Context for mock logging that tracks component instances and provides numbered identifiers
-public final class MockLogger: Sendable {
+public final class TestDRSMockLogger: Sendable {
 
     private let continuation: AsyncStream<Event>.Continuation
     private let print: @Sendable (String) -> Void
@@ -104,7 +104,7 @@ public final class MockLogger: Sendable {
 
 }
 
-extension MockLogger {
+extension TestDRSMockLogger {
 
     private struct ComponentInfo {
         let id: ObjectIdentifier
@@ -165,8 +165,8 @@ extension MockLogger {
 
 }
 
-extension MockLogger {
+extension TestDRSMockLogger {
 
-    @TaskLocal static var current: MockLogger?
+    @TaskLocal static var current: TestDRSMockLogger?
 
 }

--- a/Sources/TestDRS/Spy/Blackbox/BlackBox.swift
+++ b/Sources/TestDRS/Spy/Blackbox/BlackBox.swift
@@ -22,7 +22,7 @@ public final class BlackBox: @unchecked Sendable {
     public init(mockType: Any.Type) {
         self.mockType = mockType
 
-        MockLogger.current?.register(
+        TestDRSMockLogger.current?.register(
             component: self,
             mockType: mockType
         )
@@ -41,7 +41,7 @@ public final class BlackBox: @unchecked Sendable {
         returning outputType: Output.Type,
         signature: FunctionSignature
     ) {
-        MockLogger.current?.log(
+        TestDRSMockLogger.current?.log(
             component: self,
             mockType: mockType,
             message: "called \(signature)"

--- a/Sources/TestDRS/Stub/StubRegistry/StubRegistry.swift
+++ b/Sources/TestDRS/Stub/StubRegistry/StubRegistry.swift
@@ -21,14 +21,14 @@ public final class StubRegistry: @unchecked Sendable {
 
     public init(mockType: Any.Type) {
         self.mockType = mockType
-        MockLogger.current?.register(
+        TestDRSMockLogger.current?.register(
             component: self,
             mockType: mockType
         )
     }
 
     func setPropertyStub(stub: Stub, for propertyName: String) {
-        MockLogger.current?.log(
+        TestDRSMockLogger.current?.log(
             component: self,
             mockType: mockType,
             message: "setting \(String(describing: stub)) for \(propertyName)"
@@ -39,7 +39,7 @@ public final class StubRegistry: @unchecked Sendable {
     }
 
     func setFunctionStub(stub: Stub, for identifier: FunctionStubIdentifier) {
-        MockLogger.current?.log(
+        TestDRSMockLogger.current?.log(
             component: self,
             mockType: mockType,
             message: "setting stub for \(identifier.signature)"
@@ -57,7 +57,7 @@ public final class StubRegistry: @unchecked Sendable {
             return try stub.evaluate()
         }
 
-        MockLogger.current?.log(
+        TestDRSMockLogger.current?.log(
             component: self,
             mockType: mockType,
             message: "returning stub for property \(propertyName)"
@@ -94,7 +94,7 @@ public final class StubRegistry: @unchecked Sendable {
         // Evaluate the stub outside of the storageQueue so that we don't deadlock
         let output: Output = try stub.evaluate(with: input)
 
-        MockLogger.current?.log(
+        TestDRSMockLogger.current?.log(
             component: self,
             mockType: mockType,
             message: "returning stub for \(signature)"


### PR DESCRIPTION
## Summary
- Renamed `MockLogger` to `TestDRSMockLogger` to avoid namespace collisions with other logging implementations

## Changes
- Updated `MockLogging.swift` with the new class name and all references
- Updated `StubRegistry.swift` to use `TestDRSMockLogger` 
- Updated `BlackBox.swift` to use `TestDRSMockLogger`
- Updated `README.md` example code

## Test plan
- [x] All existing tests pass
- [x] Pre-commit hooks pass
- [x] No functionality changes, only renaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)