### PR TITLE
fix: include full diagnostic in missing stub fatalError

### DIFF
--- a/Sources/TestDRS/Stub/StubRegistry/StubRegistry+Retrieval.swift
+++ b/Sources/TestDRS/Stub/StubRegistry/StubRegistry+Retrieval.swift
@@ -120,11 +120,12 @@ extension StubRegistry {
                 Available stubs:\(String.emptyLine)\(debugDescription)
                 """
             }
-            reportFailure("""
+            let fullMessage = """
             \(errorMessage)
             Fix: #stub(mockInstance.\(memberName), returning: <value>)
-            """)
-            fatalError("Missing stub")
+            """
+            reportFailure(fullMessage)
+            fatalError(fullMessage)
         case .incorrectOutputType, .incorrectClosureType:
             handleInternalError()
         }
@@ -150,11 +151,12 @@ extension StubRegistry {
                 Available stubs:\(String.emptyLine)\(debugDescription)
                 """
             }
-            reportFailure("""
+            let fullMessage = """
             \(errorMessage)
             Fix: mockInstance.\(propertyName) = <value>
-            """)
-            fatalError("Missing stub")
+            """
+            reportFailure(fullMessage)
+            fatalError(fullMessage)
         case .incorrectOutputType, .incorrectClosureType:
             handleInternalError()
         }


### PR DESCRIPTION
## Summary
- The `fatalError("Missing stub")` message was unhelpful on CI — the process crashes before the test failure from `reportIssue` is surfaced
- Now the `fatalError` includes the full diagnostic: which type/member is missing a stub, available stubs, and a fix suggestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)