### PR TITLE
chore: bump IssueReporting dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "03b951fbbd5acdaf016d9fffa7d6d3e578cd55929530b513092fcc5cd131ba52",
+  "originHash" : "021fbc8bb2effbc4dd933efd731ed6ad9acf4552f10e8ab5e981effbecda68f8",
   "pins" : [
     {
       "identity" : "swift-custom-dump",
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "b2ed9eabefe56202ee4939dd9fc46b6241c88317",
-        "version" : "1.6.1"
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-syntax", from: "602.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.5.2"),
-        .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.6.1"),
+        .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.9.0"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.3"),
     ],
     targets: [


### PR DESCRIPTION
I was getting crashes running the test suite locally on Xcode 26.4, bumping IssueReporting fixed it.

## Summary
- Bumps `xctest-dynamic-overlay` / IssueReporting from 1.6.1 to 1.9.0.
- Updates `Package.resolved` accordingly.

## Verification
- `swift test` passed on this branch.