### PR TITLE
feat: support async dynamic stubs

### DIFF
--- a/Sources/TestDRS/Macros/StubMacros.swift
+++ b/Sources/TestDRS/Macros/StubMacros.swift
@@ -42,3 +42,15 @@ public macro stub<Input, Output>(
 @freestanding(expression)
 @discardableResult
 public macro stub<Input, Output>(_ function: (Input) async throws -> Output, using closure: (Input) throws -> Output) -> Void = #externalMacro(module: "TestDRSMacros", type: "SetStubUsingClosureMacro")
+
+/// Sets a stub for a given function using an async closure to dynamically determine the output.
+///
+/// - Parameters:
+///   - function: The function to stub. The specified function must be a member of a `StubProviding` type.
+///   - closure: An async closure that takes in the function's input and returns the desired output when the function is called.
+///
+///   - Note: Macros do not seem to support trailing syntax currently, so you must specify the argument label `using`.
+///   This also serves to disambiguate from `stub(_:returning:)` where the `Output` is a closure.
+@freestanding(expression)
+@discardableResult
+public macro stub<Input, Output>(_ function: (Input) async throws -> Output, using closure: (Input) async throws -> Output) -> Void = #externalMacro(module: "TestDRSMacros", type: "SetStubUsingClosureMacro")

--- a/Sources/TestDRS/Stub/StubProviding.swift
+++ b/Sources/TestDRS/Stub/StubProviding.swift
@@ -83,6 +83,21 @@ public extension StubProviding {
         stubRegistry.register(closure: closure, forSignature: signature)
     }
 
+    /// Sets a stub for a given function using an async closure to dynamically determine the output.
+    ///
+    /// - Parameters:
+    ///   - function: The function to stub.
+    ///   - signature: The signature of the function to stub, which can be obtained by right-clicking on the function's signature and selecting "Copy" > "Copy Symbol Name".
+    ///   This should also match what is recorded by the `#function` macro.
+    ///   - closure: An async closure that takes in the function's input and returns the desired output when the function is called.
+    func setDynamicStub<Input, Output>(
+        for function: (Input) async throws -> Output,
+        withSignature signature: FunctionSignature,
+        using closure: @escaping (Input) async throws -> Output
+    ) {
+        stubRegistry.register(asyncClosure: closure, forSignature: signature)
+    }
+
     /// Sets a stub for a given property to return a provided output.
     ///
     /// - Parameters:
@@ -125,6 +140,21 @@ public extension StubProviding {
         stubRegistry.stubOutput(for: input, signature: signature, in: Self.self)
     }
 
+    /// Retrieves the stubbed output for the calling async function based on the given input and expected output type.
+    ///
+    /// - Parameters:
+    ///   - input: The input to the calling function.
+    ///   - signature: **Do not pass in this argument**, it will automatically capture the signature of the calling function.
+    /// - Returns: The stubbed output for the calling function.
+    ///
+    /// - Precondition: A corresponding stub must be set prior to calling this function. Otherwise, a fatal error will be thrown.
+    func asyncStubOutput<Input, Output>(
+        for input: Input = Void(),
+        signature: FunctionSignature = #function
+    ) async -> Output {
+        await stubRegistry.asyncStubOutput(for: input, signature: signature, in: Self.self)
+    }
+
     /// Retrieves the stubbed output for the calling function based on the given input and expected output type, allowing for potential throwing of errors.
     ///
     /// - Parameters:
@@ -137,6 +167,20 @@ public extension StubProviding {
         signature: FunctionSignature = #function
     ) throws -> Output {
         try stubRegistry.throwingStubOutput(for: input, signature: signature, in: Self.self)
+    }
+
+    /// Retrieves the stubbed output for the calling async function based on the given input and expected output type, allowing for potential throwing of errors.
+    ///
+    /// - Parameters:
+    ///   - input: The input to the calling function.
+    ///   - signature: **Do not pass in this argument**, it will automatically capture the signature of the calling function.
+    /// - Returns: The stubbed output for the calling function, provided one has been set.
+    /// - Throws: Any error that has been set to be thrown for this function.
+    func asyncThrowingStubOutput<Input, Output>(
+        for input: Input = Void(),
+        signature: FunctionSignature = #function
+    ) async throws -> Output {
+        try await stubRegistry.asyncThrowingStubOutput(for: input, signature: signature, in: Self.self)
     }
 
     func stubValue<Output>(for propertyName: String = #function) -> Output {
@@ -202,6 +246,21 @@ public extension StubProviding {
         getStaticStubRegistry().register(closure: closure, forSignature: signature)
     }
 
+    /// Sets a stub for a given function using an async closure to dynamically determine the output.
+    ///
+    /// - Parameters:
+    ///   - function: The function to stub.
+    ///   - signature: The signature of the function to stub, which can be obtained by right-clicking on the function's signature and selecting "Copy" > "Copy Symbol Name".
+    ///   This should also match what is recorded by the `#function` macro.
+    ///   - closure: An async closure that takes in the function's input and returns the desired output when the function is called.
+    static func setDynamicStub<Input, Output>(
+        for function: (Input) async throws -> Output,
+        withSignature signature: FunctionSignature,
+        using closure: @escaping (Input) async throws -> Output
+    ) {
+        getStaticStubRegistry().register(asyncClosure: closure, forSignature: signature)
+    }
+
     /// Sets a stub for a given property to return a provided output.
     ///
     /// - Parameters:
@@ -244,6 +303,21 @@ public extension StubProviding {
         getStaticStubRegistry().stubOutput(for: input, signature: signature, in: Self.self)
     }
 
+    /// Retrieves the stubbed output for the calling async function based on the given input and expected output type.
+    ///
+    /// - Parameters:
+    ///   - input: The input to the calling function.
+    ///   - signature: **Do not pass in this argument**, it will automatically capture the signature of the calling function.
+    /// - Returns: The stubbed output for the calling function.
+    ///
+    /// - Precondition: A corresponding stub must be set prior to calling this function. Otherwise, a fatal error will be thrown.
+    static func asyncStubOutput<Input, Output>(
+        for input: Input = Void(),
+        signature: FunctionSignature = #function
+    ) async -> Output {
+        await getStaticStubRegistry().asyncStubOutput(for: input, signature: signature, in: Self.self)
+    }
+
     /// Retrieves the stubbed output for the calling function based on the given input and expected output type, allowing for potential throwing of errors.
     ///
     /// - Parameters:
@@ -256,6 +330,20 @@ public extension StubProviding {
         signature: FunctionSignature = #function
     ) throws -> Output {
         try getStaticStubRegistry().throwingStubOutput(for: input, signature: signature, in: Self.self)
+    }
+
+    /// Retrieves the stubbed output for the calling async function based on the given input and expected output type, allowing for potential throwing of errors.
+    ///
+    /// - Parameters:
+    ///   - input: The input to the calling function.
+    ///   - signature: **Do not pass in this argument**, it will automatically capture the signature of the calling function.
+    /// - Returns: The stubbed output for the calling function, provided one has been set.
+    /// - Throws: Any error that has been set to be thrown for this function.
+    static func asyncThrowingStubOutput<Input, Output>(
+        for input: Input = Void(),
+        signature: FunctionSignature = #function
+    ) async throws -> Output {
+        try await getStaticStubRegistry().asyncThrowingStubOutput(for: input, signature: signature, in: Self.self)
     }
 
     static func stubValue<Output>(for propertyName: String = #function) -> Output {

--- a/Sources/TestDRS/Stub/StubRegistry/Stub.swift
+++ b/Sources/TestDRS/Stub/StubRegistry/Stub.swift
@@ -12,6 +12,7 @@ extension StubRegistry {
         case output(Any)
         case error(Error)
         case closure(Any)
+        case asyncClosure(Any)
 
         func evaluate<Input, Output>(with input: Input = Void()) throws -> Output {
             switch self {
@@ -27,6 +28,30 @@ extension StubRegistry {
                     throw StubError.incorrectClosureType
                 }
                 return try closure(input)
+            case .asyncClosure:
+                throw StubError.asyncClosureUsedFromSynchronousContext
+            }
+        }
+
+        func evaluateAsync<Input, Output>(with input: Input = Void()) async throws -> Output {
+            switch self {
+            case .output(let output):
+                guard let output = output as? Output else {
+                    throw StubError.incorrectOutputType
+                }
+                return output
+            case .error(let error):
+                throw error
+            case .closure(let closure):
+                guard let closure = closure as? (Input) throws -> Output else {
+                    throw StubError.incorrectClosureType
+                }
+                return try closure(input)
+            case .asyncClosure(let closure):
+                guard let closure = closure as? (Input) async throws -> Output else {
+                    throw StubError.incorrectClosureType
+                }
+                return try await closure(input)
             }
         }
     }
@@ -43,6 +68,8 @@ extension StubRegistry.Stub: CustomDebugStringConvertible {
             "stubbed error: \(error)"
         case .closure:
             "stubbed using a closure"
+        case .asyncClosure:
+            "stubbed using an async closure"
         }
     }
 }

--- a/Sources/TestDRS/Stub/StubRegistry/StubError.swift
+++ b/Sources/TestDRS/Stub/StubRegistry/StubError.swift
@@ -14,6 +14,8 @@ extension StubRegistry {
         case incorrectOutputType
         /// This would indicate an issue with the `StubProviding` protocol or the `StubRegistry`.
         case incorrectClosureType
+        /// An async dynamic stub was evaluated by a synchronous stub retrieval API.
+        case asyncClosureUsedFromSynchronousContext
     }
 
 }

--- a/Sources/TestDRS/Stub/StubRegistry/StubRegistry+Registration.swift
+++ b/Sources/TestDRS/Stub/StubRegistry/StubRegistry+Registration.swift
@@ -62,4 +62,17 @@ extension StubRegistry {
         setFunctionStub(stub: .closure(closure), for: identifier)
     }
 
+    /// Registers an async closure for a given function signature.
+    ///
+    /// - Parameters:
+    ///   - closure: The async closure to be executed when the registered function is called.
+    ///   - signature: The signature of the function.
+    func register<Input, Output>(
+        asyncClosure closure: @escaping (Input) async throws -> Output,
+        forSignature signature: FunctionSignature
+    ) {
+        let identifier = FunctionStubIdentifier(signature: signature, inputType: Input.self, outputType: Output.self)
+        setFunctionStub(stub: .asyncClosure(closure), for: identifier)
+    }
+
 }

--- a/Sources/TestDRS/Stub/StubRegistry/StubRegistry+Retrieval.swift
+++ b/Sources/TestDRS/Stub/StubRegistry/StubRegistry+Retrieval.swift
@@ -69,6 +69,36 @@ extension StubRegistry {
         }
     }
 
+    /// Retrieves the stubbed output for the calling async function based on the given input and expected output type.
+    ///
+    /// - Parameters:
+    ///   - input: The input to the calling function.
+    ///   - signature: **Do not pass in this argument**, it will automatically capture the signature of the calling function.
+    ///   - stubProvidingType: The type where the stub is being retrieved.
+    /// - Returns: The stubbed output for the calling function.
+    ///
+    /// - Precondition: A corresponding stub must be set prior to calling this function. Otherwise, a fatal error will be thrown.
+    func asyncStubOutput<Input, Output>(
+        for input: Input,
+        signature: FunctionSignature,
+        in stubProvidingType: StubProviding.Type
+    ) async -> Output {
+        do {
+            return try await getOutputAsync(for: input, withSignature: signature)
+        } catch {
+            if let stubError = error as? StubRegistry.StubError {
+                report(
+                    stubError,
+                    in: stubProvidingType,
+                    signature: signature,
+                    inputType: Input.self,
+                    outputType: Output.self
+                )
+            }
+            fatalError("Unexpected error getting stub for \(signature)")
+        }
+    }
+
     /// Retrieves the stubbed output for the calling function based on the given input and expected output type, allowing for potential throwing of errors.
     ///
     /// - Parameters:
@@ -84,6 +114,33 @@ extension StubRegistry {
     ) throws -> Output {
         do {
             return try getOutput(for: input, withSignature: signature)
+        } catch let stubError as StubRegistry.StubError {
+            report(
+                stubError,
+                in: stubProvidingType,
+                signature: signature,
+                inputType: Input.self,
+                outputType: Output.self
+            )
+            fatalError("Unexpected error getting stub for \(signature)")
+        }
+    }
+
+    /// Retrieves the stubbed output for the calling async function based on the given input and expected output type, allowing for potential throwing of errors.
+    ///
+    /// - Parameters:
+    ///   - input: The input to the calling function.
+    ///   - signature: **Do not pass in this argument**, it will automatically capture the signature of the calling function.
+    ///   - stubProvidingType: The type where the stub is being retrieved.
+    /// - Returns: The stubbed output for the calling function, provided one has been set.
+    /// - Throws: Any error that has been set to be thrown for this function.
+    func asyncThrowingStubOutput<Input, Output>(
+        for input: Input,
+        signature: FunctionSignature,
+        in stubProvidingType: StubProviding.Type
+    ) async throws -> Output {
+        do {
+            return try await getOutputAsync(for: input, withSignature: signature)
         } catch let stubError as StubRegistry.StubError {
             report(
                 stubError,
@@ -128,6 +185,13 @@ extension StubRegistry {
             fatalError(fullMessage)
         case .incorrectOutputType, .incorrectClosureType:
             handleInternalError()
+        case .asyncClosureUsedFromSynchronousContext:
+            let fullMessage = """
+            Async dynamic stub configured for \(signature.name), but it was retrieved from a synchronous stub output API.
+            Fix: use asyncStubOutput/asyncThrowingStubOutput in async mocked functions.
+            """
+            reportFailure(fullMessage)
+            fatalError(fullMessage)
         }
     }
 
@@ -157,7 +221,7 @@ extension StubRegistry {
             """
             reportFailure(fullMessage)
             fatalError(fullMessage)
-        case .incorrectOutputType, .incorrectClosureType:
+        case .incorrectOutputType, .incorrectClosureType, .asyncClosureUsedFromSynchronousContext:
             handleInternalError()
         }
     }

--- a/Sources/TestDRS/Stub/StubRegistry/StubRegistry.swift
+++ b/Sources/TestDRS/Stub/StubRegistry/StubRegistry.swift
@@ -74,15 +74,7 @@ public final class StubRegistry: @unchecked Sendable {
     /// - Returns: The output value for the given input and function signature.
     /// - Throws: `StubError.noStub` if no stub is registered for the given input and function signature, or any error thrown by the registered closure.
     func getOutput<Input, Output>(for input: Input, withSignature signature: FunctionSignature) throws -> Output {
-        let stub = storageQueue.sync {
-            let identifier = FunctionStubIdentifier(signature: signature, inputType: Input.self, outputType: Output.self)
-
-            // Stubs could be set with either the full signature like `foo(paramOne:)`
-            // or if there is no ambiguity, they could be set with an abbreviated signature like `foo`.
-            // When we go to retrieve them, we should have the full signature since it is captured by #function.
-            // So first we try to retrieve using the full signature provided, and then using the abbreviated version.
-            return functionStubs[identifier] ?? functionStubs[identifier.abbreviatedIdentifier]
-        }
+        let stub: Stub? = getFunctionStub(forInputType: Input.self, outputType: Output.self, withSignature: signature)
 
         guard let stub else {
             if let void = Void() as? Output {
@@ -101,6 +93,51 @@ public final class StubRegistry: @unchecked Sendable {
         )
 
         return output
+    }
+
+    /// Retrieves the output value for a given input and function signature, allowing async dynamic stubs.
+    ///
+    /// - Parameters:
+    ///   - input: The input value for the function.
+    ///   - signature: The signature of the function.
+    /// - Returns: The output value for the given input and function signature.
+    /// - Throws: `StubError.noStub` if no stub is registered for the given input and function signature, or any error thrown by the registered closure.
+    func getOutputAsync<Input, Output>(for input: Input, withSignature signature: FunctionSignature) async throws -> Output {
+        let stub: Stub? = getFunctionStub(forInputType: Input.self, outputType: Output.self, withSignature: signature)
+
+        guard let stub else {
+            if let void = Void() as? Output {
+                return void
+            }
+            throw StubError.noStub
+        }
+
+        // Evaluate the stub outside of the storageQueue so that we don't deadlock
+        let output: Output = try await stub.evaluateAsync(with: input)
+
+        TestDRSMockLogger.current?.log(
+            component: self,
+            mockType: mockType,
+            message: "returning stub for \(signature)"
+        )
+
+        return output
+    }
+
+    private func getFunctionStub<Input, Output>(
+        forInputType inputType: Input.Type,
+        outputType: Output.Type,
+        withSignature signature: FunctionSignature
+    ) -> Stub? {
+        storageQueue.sync {
+            let identifier = FunctionStubIdentifier(signature: signature, inputType: inputType, outputType: outputType)
+
+            // Stubs could be set with either the full signature like `foo(paramOne:)`
+            // or if there is no ambiguity, they could be set with an abbreviated signature like `foo`.
+            // When we go to retrieve them, we should have the full signature since it is captured by #function.
+            // So first we try to retrieve using the full signature provided, and then using the abbreviated version.
+            return functionStubs[identifier] ?? functionStubs[identifier.abbreviatedIdentifier]
+        }
     }
 
 }

--- a/Sources/TestDRSMacros/Mocking/MockFunctionMacroExpansion.swift
+++ b/Sources/TestDRSMacros/Mocking/MockFunctionMacroExpansion.swift
@@ -35,7 +35,14 @@ public struct MockFunctionMacro: BodyMacro {
     }
 
     private static func stubOutputSyntax(for method: FunctionDeclSyntax) -> ExprSyntax {
-        FunctionCallExprSyntax(callee: ExprSyntax(stringLiteral: method.isThrowing ? "throwingStubOutput" : "stubOutput")) {
+        let callee = switch (method.isAsync, method.isThrowing) {
+        case (true, true): "asyncThrowingStubOutput"
+        case (true, false): "asyncStubOutput"
+        case (false, true): "throwingStubOutput"
+        case (false, false): "stubOutput"
+        }
+
+        let call = FunctionCallExprSyntax(callee: ExprSyntax(stringLiteral: callee)) {
             if method.hasParameters {
                 LabeledExprSyntax(
                     label: "for",
@@ -43,7 +50,10 @@ public struct MockFunctionMacro: BodyMacro {
                 )
             }
         }
-        .wrappedInTry(method.isThrowing)
+
+        let tryPrefix = method.isThrowing ? "try " : ""
+        let awaitPrefix = method.isAsync ? "await " : ""
+        return ExprSyntax(stringLiteral: "\(tryPrefix)\(awaitPrefix)\(call.trimmedDescription)")
     }
 
     private static func recordCallSyntax(for method: FunctionDeclSyntax) -> FunctionCallExprSyntax {

--- a/Sources/TestDRSMacros/SyntaxExtensions/FunctionDeclSyntax+Additions.swift
+++ b/Sources/TestDRSMacros/SyntaxExtensions/FunctionDeclSyntax+Additions.swift
@@ -27,6 +27,10 @@ extension FunctionDeclSyntax {
         signature.effectSpecifiers?.throwsClause?.throwsSpecifier != nil
     }
 
+    var isAsync: Bool {
+        signature.effectSpecifiers?.asyncSpecifier != nil
+    }
+
     var hasParameters: Bool { !signature.parameterClause.parameters.isEmpty }
 
 }

--- a/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionClassTests.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionClassTests.swift
@@ -106,7 +106,7 @@ final class AddMockMacroExpansionClassTests: AddMockMacroExpansionTestCase {
 
                 override func zab(paramOne: Int) async throws -> (() -> Void) {
                     recordCall(with: paramOne, returning: (() -> Void).self)
-                    return try throwingStubOutput(for: paramOne)
+                    return try await asyncThrowingStubOutput(for: paramOne)
                 }
 
             }

--- a/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionStructTests.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/AddMockMacroExpansionStructTests.swift
@@ -106,7 +106,7 @@ final class AddMockMacroExpansionStructTests: AddMockMacroExpansionTestCase {
 
                 func zab(paramOne: Int) async throws -> Int {
                     recordCall(with: paramOne, returning: Int.self)
-                    return try throwingStubOutput(for: paramOne)
+                    return try await asyncThrowingStubOutput(for: paramOne)
                 }
 
             }

--- a/Tests/TestDRSMacrosTests/Mocking/MockFunctionMacroExpansionTests.swift
+++ b/Tests/TestDRSMacrosTests/Mocking/MockFunctionMacroExpansionTests.swift
@@ -97,6 +97,22 @@ final class MockFunctionMacroExpansionTests: XCTestCase {
         }
     }
 
+    func testAsyncFunction_TakingInt_ReturningString() {
+        assertMacro {
+            """
+            @_MockFunction
+            func foo(paramOne: Int) async -> String
+            """
+        } expansion: {
+            """
+            func foo(paramOne: Int) async -> String {
+                recordCall(with: paramOne, returning: String.self)
+                return await asyncStubOutput(for: paramOne)
+            }
+            """
+        }
+    }
+
     func testAsyncThrowingFunction_TakingInt_ReturningBlock() {
         assertMacro {
             """
@@ -107,7 +123,7 @@ final class MockFunctionMacroExpansionTests: XCTestCase {
             """
             func foo(paramOne: Int) async throws -> (() -> Void) {
                 recordCall(with: paramOne, returning: (() -> Void).self)
-                return try throwingStubOutput(for: paramOne)
+                return try await asyncThrowingStubOutput(for: paramOne)
             }
             """
         }

--- a/Tests/TestDRSMacrosTests/Stubbing/SetStubUsingClosureMacroExpansionTests.swift
+++ b/Tests/TestDRSMacrosTests/Stubbing/SetStubUsingClosureMacroExpansionTests.swift
@@ -95,6 +95,20 @@ final class SetStubUsingClosureMacroExpansionTests: XCTestCase {
         }
     }
 
+    func testStubbingMethod_WithAsyncClosure() {
+        assertMacro {
+            """
+            #stub(mock.foo, using: { await value() })
+            """
+        } expansion: {
+            """
+            mock.setDynamicStub(for: mock.foo, withSignature: "foo", using: {
+                    await value()
+                })
+            """
+        }
+    }
+
     func testStubbingMethod_WithMultilineFormatting() {
         assertMacro {
             """

--- a/Tests/TestDRSTests/Stub/StubProvidingTests.swift
+++ b/Tests/TestDRSTests/Stub/StubProvidingTests.swift
@@ -143,6 +143,20 @@ final class StubProvidingTests: XCTestCase {
         XCTAssertEqual(resultTwo, 49)
     }
 
+    func testDynamicallyStubbingAsyncFunction_WithAsyncClosure() async {
+        var x = 1
+        stubProvider.setDynamicStub(for: stubProvider.zab, withSignature: "zab()") {
+            await asyncValue(x * 7)
+        }
+
+        let resultOne = await stubProvider.zab()
+        x = 7
+        let resultTwo = await stubProvider.zab()
+
+        XCTAssertEqual(resultOne, 7)
+        XCTAssertEqual(resultTwo, 49)
+    }
+
     func testStubbingAsyncThrowingFunction_ReturningValue() async throws {
         stubProvider.setStub(for: stubProvider.zoo, withSignature: "zoo()", returning: 7)
 
@@ -183,6 +197,27 @@ final class StubProvidingTests: XCTestCase {
         stubProvider.setDynamicStub(for: stubProvider.zoo, withSignature: "zoo()") {
             guard !shouldThrow else { throw StubProviderError() }
             return 7
+        }
+
+        let result = try await stubProvider.zoo()
+        XCTAssertEqual(result, 7)
+
+        shouldThrow = true
+
+        do {
+            _ = try await stubProvider.zoo()
+            XCTFail("Expected error to be thrown")
+        } catch _ as StubProviderError {
+            // Expected
+        } catch {
+            XCTFail("Expected error to be StubProviderError")
+        }
+    }
+
+    func testDynamicallyStubbingAsyncThrowingFunction_WithAsyncClosure() async throws {
+        var shouldThrow = false
+        stubProvider.setDynamicStub(for: stubProvider.zoo, withSignature: "zoo()") {
+            try await asyncThrowingValue(7, shouldThrow: shouldThrow)
         }
 
         let result = try await stubProvider.zoo()
@@ -360,16 +395,25 @@ private struct StubProvider: StubProviding {
     }
 
     func zab() async -> Int {
-        stubOutput()
+        await asyncStubOutput()
     }
 
     func zoo() async throws -> Int {
-        try throwingStubOutput()
+        try await asyncThrowingStubOutput()
     }
 
     static func staticFoo() -> Int {
         stubOutput()
     }
+}
+
+private func asyncValue<T>(_ value: T) async -> T {
+    value
+}
+
+private func asyncThrowingValue<T>(_ value: T, shouldThrow: Bool) async throws -> T {
+    guard !shouldThrow else { throw StubProviderError() }
+    return value
 }
 
 private struct StubProviderError: Error {}


### PR DESCRIPTION
I needed this for a personal project where I actually wanted stubs to do some async work in order to simulate a NWConnection. Wasn't a big lift to add support.

## Summary
- Adds async dynamic stub registration and retrieval APIs for instance and static `StubProviding` types.
- Updates mock macro expansion to call async stub retrieval from async mocked functions.
- Adds coverage for async closures and async/throwing mock expansion.

## Verification
- `swift test` passes